### PR TITLE
Fix timer cancellation in chat provider cleanup

### DIFF
--- a/lib/pages/backend/providers/chat_provider.dart
+++ b/lib/pages/backend/providers/chat_provider.dart
@@ -409,7 +409,7 @@ class ChatProvider with ChangeNotifier {
       _channel = null;
       
       _reconnectTimer?.cancel();
-      _refreshTimer?.cancel;
+      _refreshTimer?.cancel();
       
       _reconnectAttempts = 0;
       


### PR DESCRIPTION
## Summary
- fix typo calling `cancel` on `_refreshTimer` in `ChatProvider.cleanup`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68403718cf188323a7a525fa4ebeab89