### PR TITLE
Allow login via email

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -3,7 +3,7 @@
 This simple backend provides:
 
 - **/auth/register**: POST JSON `{"username":"user","email":"e","password":"pass"}` to create a user. Legacy `/register` remains for compatibility.
-- **/auth/login**: POST JSON to authenticate. Legacy `/login` also works.
+ - **/auth/login**: POST JSON to authenticate using either `username` or `email` along with `password`. Legacy `/login` also works.
 - **/profile**: GET returns the authenticated user's data using an `Authorization: Bearer <token>` header.
 - **/files**: GET list of all files in the project directory.
 

--- a/backend/main.go
+++ b/backend/main.go
@@ -46,7 +46,24 @@ func login(c *gin.Context) {
 	}
 	mu.Lock()
 	defer mu.Unlock()
-	stored, exists := users[u.Username]
+
+	var stored User
+	var exists bool
+
+	// Allow login using either username or email for convenience
+	if u.Username != "" {
+		stored, exists = users[u.Username]
+	}
+	if !exists && u.Email != "" {
+		for _, usr := range users {
+			if usr.Email == u.Email {
+				stored = usr
+				exists = true
+				break
+			}
+		}
+	}
+
 	if !exists || stored.Password != u.Password {
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid credentials"})
 		return


### PR DESCRIPTION
## Summary
- backend: support login using email or username
- backend docs: clarify email or username allowed for login

## Testing
- `go build ./...` *(fails: Get `https://storage.googleapis.com/...`: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68405d1799388323883ec1bdabd07ad8