### PR TITLE
Handle optional timestamps in User model

### DIFF
--- a/lib/pages/backend/models/user_model.dart
+++ b/lib/pages/backend/models/user_model.dart
@@ -41,10 +41,10 @@ class User {
   final List<String> following;
 
   @JsonKey(name: 'createdAt')
-  final DateTime createdAt;
+  final DateTime? createdAt;
 
   @JsonKey(name: 'updatedAt')
-  final DateTime updatedAt;
+  final DateTime? updatedAt;
 
   @JsonKey(defaultValue: <String>[])
   final List<String> conversations;
@@ -62,8 +62,8 @@ class User {
     this.isPrivate = false,
     this.followers = const [],
     this.following = const [],
-    required this.createdAt,
-    required this.updatedAt,
+    this.createdAt,
+    this.updatedAt,
     this.conversations = const [],
   });
 
@@ -81,8 +81,12 @@ class User {
       following: List<String>.from(json['following'] ?? []),
       followers: List<String>.from(json['followers'] ?? []),
       conversations: List<String>.from(json['conversations'] ?? []),
-      createdAt: DateTime.parse(json['createdAt']),
-      updatedAt: DateTime.parse(json['updatedAt']),
+      createdAt: json['createdAt'] != null
+          ? DateTime.parse(json['createdAt'])
+          : null,
+      updatedAt: json['updatedAt'] != null
+          ? DateTime.parse(json['updatedAt'])
+          : null,
     );
   }
 
@@ -100,8 +104,8 @@ class User {
       'following': following,
       'followers': followers,
       'conversations': conversations,
-      'createdAt': createdAt.toIso8601String(),
-      'updatedAt': updatedAt.toIso8601String(),
+      if (createdAt != null) 'createdAt': createdAt!.toIso8601String(),
+      if (updatedAt != null) 'updatedAt': updatedAt!.toIso8601String(),
     };
   }
 

--- a/lib/pages/backend/models/user_model.g.dart
+++ b/lib/pages/backend/models/user_model.g.dart
@@ -30,8 +30,12 @@ User _$UserFromJson(Map<String, dynamic> json) {
             ?.map((e) => e as String)
             .toList() ??
         [],
-    createdAt: DateTime.parse(json['createdAt'] as String),
-    updatedAt: DateTime.parse(json['updatedAt'] as String),
+    createdAt: json['createdAt'] == null
+        ? null
+        : DateTime.parse(json['createdAt'] as String),
+    updatedAt: json['updatedAt'] == null
+        ? null
+        : DateTime.parse(json['updatedAt'] as String),
     conversations: (json['conversations'] as List<dynamic>?)
             ?.map((e) => e as String)
             .toList() ??
@@ -52,7 +56,7 @@ Map<String, dynamic> _$UserToJson(User instance) => <String, dynamic>{
       'isPrivate': instance.isPrivate,
       'followers': instance.followers,
       'following': instance.following,
-      'createdAt': instance.createdAt.toIso8601String(),
-      'updatedAt': instance.updatedAt.toIso8601String(),
+      'createdAt': instance.createdAt?.toIso8601String(),
+      'updatedAt': instance.updatedAt?.toIso8601String(),
       'conversations': instance.conversations,
     };


### PR DESCRIPTION
## Summary
- make `createdAt` and `updatedAt` nullable in `User` model
- update JSON serialization to handle missing timestamp fields

## Testing
- `go vet ./...` *(fails: Forbidden downloading module)*
- `go build ./...` *(fails: Forbidden downloading module)*

------
https://chatgpt.com/codex/tasks/task_e_68405fef7a988323be42d96ee656a284