### PR TITLE
Add avatar upload support to backend

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -3,8 +3,10 @@
 This simple backend provides:
 
 - **/auth/register**: POST JSON `{"username":"user","email":"e","password":"pass"}` to create a user. Legacy `/register` remains for compatibility.
- - **/auth/login**: POST JSON to authenticate using either `username` or `email` along with `password`. Legacy `/login` also works.
+- **/auth/login**: POST JSON to authenticate using either `username` or `email` along with `password`. Legacy `/login` also works.
 - **/profile**: GET returns the authenticated user's data using an `Authorization: Bearer <token>` header.
+- **/profile**: PUT updates the user's profile fields (`username`, `email`, `bio`, `phone`).
+- **/profile/avatar**: POST multipart form with an `avatar` file to upload a profile picture. Files are saved under `uploads/avatars/` and served from `/uploads`.
 - **/files**: GET list of all files in the project directory.
 
 All Go dependencies are vendored so the project can be built without network access.


### PR DESCRIPTION
## Summary
- expand Go `User` model
- implement profile update and avatar upload handlers
- expose `uploads` folder over HTTP
- document the new endpoints

## Testing
- `go build ./...` *(fails: forbidden downloading dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68406baf7ed483239f5cb90613d64cef