### PR TITLE
Persist user utilities and fix assets

### DIFF
--- a/lib/pages/acasa/utile/meditation_page.dart
+++ b/lib/pages/acasa/utile/meditation_page.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:provider/provider.dart';
+import '../../../pages/backend/providers/auth_provider.dart';
+import '../../../services/user_utils_service.dart';
 import '../../../providers/utils_provider.dart';
 import 'dart:async';
 import 'dart:math' as math;

--- a/lib/pages/acasa/utile/reflections_page.dart
+++ b/lib/pages/acasa/utile/reflections_page.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'dart:convert';
+import 'package:provider/provider.dart';
+import '../../../pages/backend/providers/auth_provider.dart';
+import '../../../services/user_utils_service.dart';
 import 'package:intl/intl.dart';
 import 'package:flutter_animate/flutter_animate.dart';
 import 'package:google_fonts/google_fonts.dart';
@@ -58,6 +61,18 @@ class _ReflectionsPageState extends State<ReflectionsPage> with SingleTickerProv
     setState(() {
       _isLoading = false;
     });
+
+    final auth = context.read<AuthProvider>();
+    if (auth.isAuthenticated && auth.token != null) {
+      final service = UserUtilsService(auth.token!);
+      final data = await service.fetchUtils();
+      if (data['reflections'] != null) {
+        _reflections
+          ..clear()
+          ..addAll(List<Map<String, dynamic>>.from(data['reflections'] as List));
+      }
+      setState(() {});
+    }
   }
 
   Future<void> _saveReflection(String text) async {
@@ -77,6 +92,12 @@ class _ReflectionsPageState extends State<ReflectionsPage> with SingleTickerProv
     final prefs = await SharedPreferences.getInstance();
     await prefs.setString('reflections', json.encode(_reflections));
     _textController.clear();
+
+    final auth = context.read<AuthProvider>();
+    if (auth.isAuthenticated && auth.token != null) {
+      final service = UserUtilsService(auth.token!);
+      await service.saveUtils({'reflections': _reflections});
+    }
   }
 
   Color _getRandomPastelColor() {
@@ -98,6 +119,12 @@ class _ReflectionsPageState extends State<ReflectionsPage> with SingleTickerProv
 
     final prefs = await SharedPreferences.getInstance();
     await prefs.setString('reflections', json.encode(_reflections));
+
+    final auth = context.read<AuthProvider>();
+    if (auth.isAuthenticated && auth.token != null) {
+      final service = UserUtilsService(auth.token!);
+      await service.saveUtils({'reflections': _reflections});
+    }
   }
 
   @override

--- a/lib/pages/acasa/utile/workout_page.dart
+++ b/lib/pages/acasa/utile/workout_page.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'models/workout_models.dart';
 import 'data/workout_data.dart';
 import 'widgets/modern_workout_widgets.dart';
+import 'package:provider/provider.dart';
+import '../../../providers/utils_provider.dart' as utils;
 
 class WorkoutPage extends StatefulWidget {
   const WorkoutPage({super.key});
@@ -608,6 +610,10 @@ class _WorkoutPageState extends State<WorkoutPage> {
         onPressed: () {
           setState(() => _isExercising = !_isExercising);
           if (!_isExercising) {
+            context.read<utils.UtilsProvider>().logWorkout(
+                  exercise.name,
+                  exercise.duration,
+                );
             Navigator.pop(context);
           }
         },

--- a/lib/providers/utils_provider.dart
+++ b/lib/providers/utils_provider.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:just_audio/just_audio.dart';
 import 'dart:convert';
+import '../services/user_utils_service.dart';
 
 class PomodoroSettings {
   int workDuration; // in minutes
@@ -303,6 +304,20 @@ class UtilsProvider extends ChangeNotifier {
     await prefs.setString('reflections', jsonEncode(_reflections.map((e) => e.toJson()).toList()));
     await prefs.setString('meditationHistory', jsonEncode(_meditationHistory.map((e) => e.toJson()).toList()));
     await prefs.setString('workoutHistory', jsonEncode(_workoutHistory.map((e) => e.toJson()).toList()));
+
+    final auth = await SharedPreferences.getInstance();
+    final token = auth.getString('auth_token');
+    if (token != null) {
+      final service = UserUtilsService(token);
+      await service.saveUtils({
+        'pomodoro_settings': _pomodoroSettings.toJson(),
+        'waterIntake': _waterIntake.toJson(),
+        'sleepHistory': _sleepHistory.map((k, v) => MapEntry(k.toIso8601String(), v.toJson())),
+        'reflections': _reflections.map((e) => e.toJson()).toList(),
+        'meditationHistory': _meditationHistory.map((e) => e.toJson()).toList(),
+        'workoutHistory': _workoutHistory.map((e) => e.toJson()).toList(),
+      });
+    }
   }
   
   // Pomodoro methods

--- a/lib/services/user_utils_service.dart
+++ b/lib/services/user_utils_service.dart
@@ -1,0 +1,35 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+
+import '../pages/backend/services/api_service.dart';
+
+class UserUtilsService {
+  final String token;
+
+  UserUtilsService(this.token);
+
+  Map<String, String> get _headers => {
+        'Content-Type': 'application/json',
+        'Authorization': 'Bearer $token',
+      };
+
+  Future<Map<String, dynamic>> fetchUtils() async {
+    final response = await http.get(
+      Uri.parse('${ApiService.baseUrl}/utils'),
+      headers: _headers,
+    );
+    if (response.statusCode == 200) {
+      return jsonDecode(response.body) as Map<String, dynamic>;
+    }
+    return {};
+  }
+
+  Future<void> saveUtils(Map<String, dynamic> data) async {
+    await http.put(
+      Uri.parse('${ApiService.baseUrl}/utils'),
+      headers: _headers,
+      body: jsonEncode(data),
+    );
+  }
+}
+

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -70,10 +70,12 @@ flutter:
     - assets/carti/cartidp/
     - assets/carti/cartidpp/
     - assets/sounds/
+    - assets/sounds/sleep/
     - assets/animations/
     - assets/icons/
     - assets/clasament/
     - assets/utile/
+    - assets/utile/peisaj/
     - assets/icon/
     - assets/level/
     - assets/carusel/


### PR DESCRIPTION
## Summary
- persist Pomodoro, water, sleep, reflections, meditation and workouts with a new `UserUtilsService`
- expose `/utils` API on the backend for storing user data
- sync utility pages with backend when saving/loading
- log workouts when finishing an exercise
- include sleep images and sounds in `pubspec.yaml`

## Testing
- `go build` *(fails: forbidden when downloading modules)*

------
https://chatgpt.com/codex/tasks/task_e_68406fd130e88323bdc383fa9939871d