### PR TITLE
Fix web assets and websocket

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,6 +7,7 @@ import 'pages/modern_code_reader.dart';
 import 'pages/backend/providers/auth_provider.dart';
 import 'pages/backend/providers/chat_provider.dart';
 import 'pages/backend/providers/level_provider.dart';
+import 'providers/obiective_provider.dart';
 
 void main() {
   runApp(const MyApp());
@@ -20,6 +21,7 @@ class MyApp extends StatelessWidget {
     return MultiProvider(
       providers: [
         ChangeNotifierProvider(create: (_) => AuthProvider()),
+        ChangeNotifierProvider(create: (_) => ObiectiveProvider()),
         ChangeNotifierProvider(
           create: (context) => ChatProvider(context.read<AuthProvider>().token),
         ),

--- a/lib/pages/backend/providers/auth_provider.dart
+++ b/lib/pages/backend/providers/auth_provider.dart
@@ -6,6 +6,7 @@ import '../services/api_service_login.dart';
 import 'dart:io';
 import 'dart:convert';
 import 'package:http/http.dart' as http;
+import 'package:image_picker/image_picker.dart';
 
 class AuthProvider extends ChangeNotifier {
   User? _currentUser;
@@ -224,14 +225,18 @@ class AuthProvider extends ChangeNotifier {
     }
   }
 
-  Future<void> updateAvatar(String filePath) async {
+  Future<void> updateAvatar(XFile image) async {
     try {
       if (_token == null) {
         throw Exception('Nu sunteți autentificat');
       }
 
-      print('Attempting to update avatar with file: $filePath');
-      final updatedUser = await _apiService.updateAvatar(filePath);
+      print('Attempting to update avatar with file: ${image.path}');
+      final updatedUser = await _apiService.updateAvatar(
+        image.path,
+        bytes: kIsWeb ? await image.readAsBytes() : null,
+        filename: image.name,
+      );
       _currentUser = updatedUser;
       print('Avatar updated successfully');
       notifyListeners();

--- a/lib/pages/profil/edit_profile_screen.dart
+++ b/lib/pages/profil/edit_profile_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:provider/provider.dart';
 import 'package:image_picker/image_picker.dart';
+import 'package:flutter/foundation.dart';
 import '../backend/models/user_model.dart';
 import '../backend/providers/auth_provider.dart';
 import 'dart:io';
@@ -57,19 +58,21 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
       if (image != null) {
         print('Selected image path: ${image.path}');
         
-        final file = File(image.path);
-        if (!await file.exists()) {
-          throw Exception('Fișierul nu există la calea: ${image.path}');
+        if (!kIsWeb) {
+          final file = File(image.path);
+          if (!await file.exists()) {
+            throw Exception('Fișierul nu există la calea: ${image.path}');
+          }
+
+          final fileSize = await file.length();
+          print('File size before compression: ${fileSize} bytes');
+
+          if (fileSize > 5 * 1024 * 1024) {
+            throw Exception('Imaginea este prea mare. Vă rugăm să alegeți o imagine mai mică.');
+          }
         }
-        
-        final fileSize = await file.length();
-        print('File size before compression: ${fileSize} bytes');
-        
-        if (fileSize > 5 * 1024 * 1024) {
-          throw Exception('Imaginea este prea mare. Vă rugăm să alegeți o imagine mai mică.');
-        }
-        
-        await context.read<AuthProvider>().updateAvatar(image.path);
+
+        await context.read<AuthProvider>().updateAvatar(image);
         
         if (mounted) {
           ScaffoldMessenger.of(context).showSnackBar(


### PR DESCRIPTION
## Summary
- create assets/images folder to resolve pubspec error
- add ObiectiveProvider to app providers
- allow token via query for websocket and expose online users endpoint in backend
- support web upload for avatars
- use cross‑platform websocket channel on web

## Testing
- `dart format` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68407560a138832399a61dcbc8c9a38c