### PR TITLE
Fix user auth and improve auth pages

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -2,7 +2,7 @@
 
 This simple backend provides:
 
-- **/auth/register**: POST JSON `{"username":"user","email":"e","password":"pass"}` to create a user. Legacy `/register` remains for compatibility.
+- **/auth/register**: POST JSON `{"username":"user","email":"e","password":"pass"}` to create a user.  Usernames and emails must be unique. Legacy `/register` remains for compatibility.
 - **/auth/login**: POST JSON to authenticate using either `username` or `email` along with `password`. Legacy `/login` also works.
 - **/profile**: GET returns the authenticated user's data using an `Authorization: Bearer <token>` header.
 - **/profile**: PUT updates the user's profile fields (`username`, `email`, `bio`, `phone`).

--- a/backend/main.go
+++ b/backend/main.go
@@ -95,20 +95,26 @@ func listBooks(c *gin.Context) {
 }
 
 func register(c *gin.Context) {
-	var u User
-	if err := c.BindJSON(&u); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid payload"})
-		return
-	}
-	mu.Lock()
-	defer mu.Unlock()
-	if _, exists := users[u.Username]; exists {
-		c.JSON(http.StatusConflict, gin.H{"error": "user exists"})
-		return
-	}
-	u.ID = uuid.New().String()
-	users[u.Username] = u
-	c.JSON(http.StatusCreated, gin.H{"user": u})
+        var u User
+        if err := c.BindJSON(&u); err != nil {
+                c.JSON(http.StatusBadRequest, gin.H{"error": "invalid payload"})
+                return
+        }
+        mu.Lock()
+        defer mu.Unlock()
+        if _, exists := users[u.Username]; exists {
+                c.JSON(http.StatusConflict, gin.H{"error": "user exists"})
+                return
+        }
+        for _, existing := range users {
+                if existing.Email == u.Email {
+                        c.JSON(http.StatusConflict, gin.H{"error": "email exists"})
+                        return
+                }
+        }
+        u.ID = uuid.New().String()
+        users[u.Username] = u
+        c.JSON(http.StatusCreated, gin.H{"user": u})
 }
 
 func login(c *gin.Context) {

--- a/lib/pages/backend/auth/login_page.dart
+++ b/lib/pages/backend/auth/login_page.dart
@@ -13,7 +13,7 @@ class LoginPage extends StatefulWidget {
 }
 
 class _LoginPageState extends State<LoginPage> {
-  final _emailController = TextEditingController();
+  final _identifierController = TextEditingController();
   final _passwordController = TextEditingController();
   bool _isLoading = false;
   bool _obscurePassword = true;
@@ -27,7 +27,7 @@ class _LoginPageState extends State<LoginPage> {
 
   @override
   void dispose() {
-    _emailController.dispose();
+    _identifierController.dispose();
     _passwordController.dispose();
     super.dispose();
   }
@@ -42,7 +42,7 @@ class _LoginPageState extends State<LoginPage> {
   }
 
   Future<void> _login() async {
-    if (_emailController.text.isEmpty || _passwordController.text.isEmpty) {
+    if (_identifierController.text.isEmpty || _passwordController.text.isEmpty) {
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(content: Text('Te rugăm să completezi toate câmpurile')),
       );
@@ -55,7 +55,7 @@ class _LoginPageState extends State<LoginPage> {
       print('Attempting login from LoginPage'); // Debug print
       final authProvider = context.read<AuthProvider>();
       await authProvider.login(
-        email: _emailController.text,
+        identifier: _identifierController.text,
         password: _passwordController.text,
       );
       print('Login successful, checking authentication status'); // Debug print
@@ -84,6 +84,7 @@ class _LoginPageState extends State<LoginPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      backgroundColor: Colors.white,
       body: SafeArea(
         child: SingleChildScrollView(
           padding: const EdgeInsets.all(24.0),
@@ -110,15 +111,15 @@ class _LoginPageState extends State<LoginPage> {
               ),
               const SizedBox(height: 48),
               TextField(
-                controller: _emailController,
+                controller: _identifierController,
                 decoration: InputDecoration(
-                  labelText: 'Email',
-                  prefixIcon: const Icon(Icons.email_outlined),
+                  labelText: 'Email sau Nume utilizator',
+                  prefixIcon: const Icon(Icons.person_outline),
                   border: OutlineInputBorder(
                     borderRadius: BorderRadius.circular(12),
                   ),
                 ),
-                keyboardType: TextInputType.emailAddress,
+                keyboardType: TextInputType.text,
               ),
               const SizedBox(height: 16),
               TextField(

--- a/lib/pages/backend/auth/register_page.dart
+++ b/lib/pages/backend/auth/register_page.dart
@@ -60,7 +60,7 @@ class _RegisterPageState extends State<RegisterPage> {
       // Autentificare automată după înregistrare
       if (mounted) {
         await context.read<AuthProvider>().login(
-          email: _emailController.text,
+          identifier: _emailController.text,
           password: _passwordController.text,
         );
 
@@ -86,6 +86,7 @@ class _RegisterPageState extends State<RegisterPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      backgroundColor: Colors.white,
       appBar: AppBar(
         title: Text(
           'Înregistrare',

--- a/lib/pages/backend/providers/auth_provider.dart
+++ b/lib/pages/backend/providers/auth_provider.dart
@@ -53,13 +53,13 @@ class AuthProvider extends ChangeNotifier {
   User? get currentUser => _currentUser;
   ApiServiceLogin get apiService => _apiService;
 
-  Future<void> login({required String email, required String password}) async {
+  Future<void> login({required String identifier, required String password}) async {
     try {
       print('Starting login process');
-      
+
       final tempApiService = ApiServiceLogin(token: null);
       final response = await tempApiService.login(
-        email: email,
+        identifier: identifier,
         password: password,
       );
 

--- a/lib/pages/backend/services/api_service_login.dart
+++ b/lib/pages/backend/services/api_service_login.dart
@@ -19,16 +19,16 @@ class ApiServiceLogin extends ApiService {
   ApiServiceLogin({super.token});
 
   Future<Map<String, dynamic>> login({
-    required String email,
+    required String identifier,
     required String password,
   }) async {
-    print('Attempting login for email: $email');
+    print('Attempting login for identifier: $identifier');
     try {
       final response = await http.post(
         Uri.parse('${ApiService.baseUrl}/auth/login'),
         headers: headers,
         body: jsonEncode({
-          'email': email,
+          identifier.contains('@') ? 'email' : 'username': identifier,
           'password': password,
         }),
       );


### PR DESCRIPTION
## Summary
- enforce unique emails during registration
- handle login with username or email on the client
- tweak login and registration UI with white background
- document uniqueness requirement in backend README

## Testing
- `go build ./...` *(fails: forbidden when downloading dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68407c91524083238d50a111c0a0a021