### PR TITLE
Fix avatar URL

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"github.com/gorilla/websocket"
@@ -329,7 +330,12 @@ func uploadAvatar(c *gin.Context) {
 		return
 	}
 
-	user.AvatarURL = "/uploads/avatars/" + filename
+	scheme := "http"
+	if c.Request.TLS != nil {
+		scheme = "https"
+	}
+	host := c.Request.Host
+	user.AvatarURL = fmt.Sprintf("%s://%s/uploads/avatars/%s", scheme, host, filename)
 
 	mu.Lock()
 	users[user.Username] = user


### PR DESCRIPTION
## Summary
- return absolute avatar URL with scheme and host

## Testing
- `go build ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684145127de4832398fd54582aad04d0