### PR TITLE
Convert dashboard to React with TypeScript

### DIFF
--- a/dashbord-react/README.md
+++ b/dashbord-react/README.md
@@ -1,0 +1,15 @@
+# Dashbord React
+
+This folder contains a simple admin dashboard implemented with React and TypeScript using [Vite](https://vitejs.dev/).
+
+## Development
+
+Install dependencies and start the development server:
+
+```bash
+npm install
+npm run dev
+```
+
+The application will be available at `http://localhost:5173` by default.
+

--- a/dashbord-react/books.json
+++ b/dashbord-react/books.json
@@ -1,0 +1,14 @@
+[
+  {
+    "id": "civil_1",
+    "title": "Despre persoane",
+    "image": "../assets/carti/1.png",
+    "content": "Sample content"
+  },
+  {
+    "id": "civil_2",
+    "title": "Căsătoria",
+    "image": "../assets/carti/2.png",
+    "content": "Sample content"
+  }
+]

--- a/dashbord-react/index.html
+++ b/dashbord-react/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Admin Dashboard</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/dashbord-react/package.json
+++ b/dashbord-react/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "dashbord-react",
+  "private": true,
+  "version": "0.1.0",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
+    "@vitejs/plugin-react": "^4.0.0",
+    "typescript": "^5.0.2",
+    "vite": "^4.4.9"
+  }
+}

--- a/dashbord-react/src/App.tsx
+++ b/dashbord-react/src/App.tsx
@@ -1,0 +1,222 @@
+import React, { useEffect, useState } from 'react';
+
+interface LoginProps {
+  onLogin: () => void;
+}
+
+function Login({ onLogin }: LoginProps) {
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (username === 'admin' && password === 'admin') {
+      onLogin();
+    } else {
+      alert('Invalid credentials');
+    }
+  };
+
+  return (
+    <div className="login">
+      <h3>Admin Login</h3>
+      <form onSubmit={handleSubmit}>
+        <div>
+          <input
+            placeholder="Username"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+          />
+        </div>
+        <div style={{ marginTop: 10 }}>
+          <input
+            type="password"
+            placeholder="Password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+          />
+        </div>
+        <button style={{ marginTop: 10 }} type="submit">
+          Login
+        </button>
+      </form>
+    </div>
+  );
+}
+
+const sections = [
+  { key: 'materie', label: 'Materie', icon: 'menu_book' },
+  { key: 'codes', label: 'Codurile actualizate', icon: 'library_books' },
+  { key: 'abonamente', label: 'Abonamente', icon: 'subscriptions' },
+  { key: 'comportament', label: 'Comportament', icon: 'psychology' },
+  { key: 'utilizatori', label: 'Utilizatori', icon: 'people' },
+  { key: 'noutati', label: 'Noutati', icon: 'feed' },
+];
+
+interface SidebarProps {
+  active: string;
+  onSelect: (key: string) => void;
+}
+
+function Sidebar({ active, onSelect }: SidebarProps) {
+  return (
+    <div className="sidebar">
+      <ul>
+        {sections.map((s) => (
+          <li
+            key={s.key}
+            className={active === s.key ? 'active' : ''}
+            onClick={() => onSelect(s.key)}
+          >
+            <span className="material-icons">{s.icon}</span>
+            {s.label}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+interface Book {
+  id: string;
+  title: string;
+  image: string;
+  content: string;
+}
+
+interface BookCarouselProps {
+  title: string;
+  books: Book[];
+  onSelect: (b: Book) => void;
+}
+
+function BookCarousel({ title, books, onSelect }: BookCarouselProps) {
+  return (
+    <div>
+      <h3>{title}</h3>
+      <div className="carousel">
+        {books.map((b) => (
+          <div className="book-card" key={b.id} onClick={() => onSelect(b)}>
+            <img src={b.image} alt={b.title} />
+            <div>{b.title}</div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+interface MaterieProps {
+  books: Book[];
+  onUpdate: (books: Book[]) => void;
+}
+
+function Materie({ books, onUpdate }: MaterieProps) {
+  const [selected, setSelected] = useState<Book | null>(null);
+  const [form, setForm] = useState({ title: '', image: '', content: '' });
+
+  const categories = [
+    { prefix: 'civil', label: 'Drept civil' },
+    { prefix: 'dpc', label: 'Drept procesual civil' },
+    { prefix: 'dp_', label: 'Drept penal' },
+    { prefix: 'dpp', label: 'Drept procesual penal' },
+  ];
+
+  const filter = (p: string) => books.filter((b) => b.id.startsWith(p));
+
+  const handleSelect = (b: Book) => {
+    setSelected(b);
+    setForm({ title: b.title, image: b.image, content: b.content });
+  };
+
+  const save = () => {
+    if (!selected) return;
+    const updated = books.map((b) => (b.id === selected.id ? { ...b, ...form } : b));
+    onUpdate(updated);
+    setSelected(null);
+  };
+
+  return (
+    <div>
+      {categories.map((cat) => (
+        <BookCarousel
+          key={cat.prefix}
+          title={cat.label}
+          books={filter(cat.prefix)}
+          onSelect={handleSelect}
+        />
+      ))}
+      {selected && (
+        <div className="editor">
+          <h3>Edit {selected.title}</h3>
+          <input
+            value={form.title}
+            onChange={(e) => setForm({ ...form, title: e.target.value })}
+            placeholder="Title"
+          />
+          <input
+            value={form.image}
+            onChange={(e) => setForm({ ...form, image: e.target.value })}
+            placeholder="Image URL"
+          />
+          <textarea
+            rows={6}
+            value={form.content}
+            onChange={(e) => setForm({ ...form, content: e.target.value })}
+            placeholder="Content"
+          />
+          <button onClick={save}>Save</button>
+          <button onClick={() => setSelected(null)}>Cancel</button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Dashboard() {
+  const [books, setBooks] = useState<Book[]>([]);
+  const [section, setSection] = useState('materie');
+
+  useEffect(() => {
+    fetch('/api/books')
+      .then((r) => r.json())
+      .then(setBooks);
+  }, []);
+
+  const updateBooks = (updated: Book[]) => {
+    setBooks(updated);
+    fetch('/api/save-books', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(updated),
+    });
+  };
+
+  const renderSection = () => {
+    if (section === 'materie') {
+      return <Materie books={books} onUpdate={updateBooks} />;
+    }
+    const s = sections.find((x) => x.key === section);
+    return (
+      <div className="placeholder">
+        <h2>{s?.label}</h2>
+        <p>Coming soon...</p>
+      </div>
+    );
+  };
+
+  return (
+    <div className="dashboard">
+      <Sidebar active={section} onSelect={setSection} />
+      <div className="content">{renderSection()}</div>
+    </div>
+  );
+}
+
+function App() {
+  const [logged, setLogged] = useState(false);
+  return logged ? <Dashboard /> : <Login onLogin={() => setLogged(true)} />;
+}
+
+export default App;
+

--- a/dashbord-react/src/index.css
+++ b/dashbord-react/src/index.css
@@ -1,0 +1,101 @@
+body {
+  font-family: Arial, sans-serif;
+  background: #f2f2f2;
+  margin: 0;
+  padding: 0;
+}
+
+.login {
+  max-width: 300px;
+  margin: 100px auto;
+  padding: 20px;
+  background: #fff;
+  border-radius: 4px;
+  box-shadow: 0 2px 5px rgba(0,0,0,0.2);
+}
+
+.dashboard {
+  display: flex;
+  height: 100vh;
+}
+
+.sidebar {
+  width: 220px;
+  background: #fff;
+  border-right: 1px solid #ddd;
+}
+
+.sidebar ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.sidebar li {
+  display: flex;
+  align-items: center;
+  padding: 12px 20px;
+  cursor: pointer;
+}
+
+.sidebar li.active,
+.sidebar li:hover {
+  background: #f0f0f0;
+}
+
+.sidebar .material-icons {
+  margin-right: 8px;
+}
+
+.content {
+  flex: 1;
+  padding: 20px;
+  overflow-y: auto;
+}
+
+.carousel {
+  display: flex;
+  overflow-x: auto;
+  padding-bottom: 10px;
+}
+
+.book-card {
+  flex: 0 0 auto;
+  width: 150px;
+  margin-right: 10px;
+  background: #fff;
+  border: 1px solid #ccc;
+  padding: 10px;
+  cursor: pointer;
+}
+
+.book-card img {
+  width: 100%;
+  height: auto;
+}
+
+.editor {
+  margin-top: 20px;
+  background: #fff;
+  padding: 20px;
+  border: 1px solid #ccc;
+}
+
+.editor input,
+.editor textarea {
+  width: 100%;
+  margin-top: 10px;
+}
+
+.placeholder {
+  padding: 20px;
+}
+
+@media (max-width: 600px) {
+  .sidebar {
+    width: 180px;
+  }
+  .book-card {
+    width: 120px;
+  }
+}

--- a/dashbord-react/src/main.tsx
+++ b/dashbord-react/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/dashbord-react/tsconfig.json
+++ b/dashbord-react/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/dashbord-react/tsconfig.node.json
+++ b/dashbord-react/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/dashbord-react/vite.config.ts
+++ b/dashbord-react/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    open: true
+  }
+});


### PR DESCRIPTION
## Summary
- add a React+TypeScript version of the dashboard under `dashbord-react`
- include Vite configuration and basic app scaffolding
- port existing dashboard logic to `App.tsx`
- provide README with instructions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68414921919483239c45b812ec64ebf6