### PR TITLE
Fix React dashboard API fetch

### DIFF
--- a/dashbord-react/README.md
+++ b/dashbord-react/README.md
@@ -12,4 +12,7 @@ npm run dev
 ```
 
 The application will be available at `http://localhost:5173` by default.
+API requests to paths starting with `/api` are proxied to the Go backend
+running on `http://localhost:8080`. Make sure the backend server is running
+for the dashboard to load the books data correctly.
 

--- a/dashbord-react/vite.config.ts
+++ b/dashbord-react/vite.config.ts
@@ -4,6 +4,9 @@ import react from '@vitejs/plugin-react';
 export default defineConfig({
   plugins: [react()],
   server: {
-    open: true
+    open: true,
+    proxy: {
+      '/api': 'http://localhost:8080'
+    }
   }
 });


### PR DESCRIPTION
## Summary
- set up Vite dev proxy so React dashboard talks to backend
- document API proxy in dashboard README

## Testing
- `npm run build` in `dashbord-react`

------
https://chatgpt.com/codex/tasks/task_e_68415157791c83238e73d91ad200d019