### PR TITLE
Fix vite server config

### DIFF
--- a/dashbord-react/vite.config.ts
+++ b/dashbord-react/vite.config.ts
@@ -3,8 +3,12 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
+  publicDir: '..',
   server: {
-    open: true,
+    open: false,
+    fs: {
+      allow: ['..']
+    },
     proxy: {
       '/api': 'http://localhost:8080'
     }


### PR DESCRIPTION
## Summary
- update vite dev server config to disable auto open and serve assets from repo root

## Testing
- `npm run dev` *(fails: `vite: not found` because dependencies are not installed)*
- `go run .` *(fails: module download forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684152f6934c832399507ca8704e7203