### PR TITLE
Fix React dashboard serving path

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -80,6 +80,8 @@ func getDashboardPath() string {
 	// is the common case when running `go run .` during development
 	if wd, err := os.Getwd(); err == nil {
 		candidates := []string{
+			filepath.Join(wd, "dashbord-react", "dist"),
+			filepath.Join(wd, "..", "dashbord-react", "dist"),
 			filepath.Join(wd, "dashbord-react"),
 			filepath.Join(wd, "..", "dashbord-react"),
 		}
@@ -94,6 +96,8 @@ func getDashboardPath() string {
 	// server is built and executed from another directory.
 	if exe, err := os.Executable(); err == nil {
 		candidates := []string{
+			filepath.Join(filepath.Dir(exe), "dashbord-react", "dist"),
+			filepath.Join(filepath.Dir(exe), "..", "dashbord-react", "dist"),
 			filepath.Join(filepath.Dir(exe), "dashbord-react"),
 			filepath.Join(filepath.Dir(exe), "..", "dashbord-react"),
 		}

--- a/dashbord-react/README.md
+++ b/dashbord-react/README.md
@@ -16,3 +16,15 @@ API requests to paths starting with `/api` are proxied to the Go backend
 running on `http://localhost:8080`. Make sure the backend server is running
 for the dashboard to load the books data correctly.
 
+## Production build
+
+To serve the dashboard through the Go backend, first create the static files:
+
+```bash
+npm run build
+```
+
+This generates a `dist/` folder that the Go server exposes at
+`http://localhost:8080/controlpanel` when running `go run ./backend` from the
+project root.
+


### PR DESCRIPTION
## Summary
- serve built dashboard files from `dashbord-react/dist`
- document how to build the React dashboard

## Testing
- `go build ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68415a4ae6dc83239761678df2ab62a9