### PR TITLE
Add rich editor and HTML rendering

### DIFF
--- a/dashbord-react/books.json
+++ b/dashbord-react/books.json
@@ -394,5 +394,47 @@
     "title": "DPP 37",
     "image": "carti/cartidpp/37.png",
     "content": "Sample content"
+  },
+  {
+    "id": "inm_1",
+    "title": "INM 1",
+    "image": "carti/cartidpp/19.png",
+    "content": "Sample content"
+  },
+  {
+    "id": "inm_2",
+    "title": "INM 2",
+    "image": "carti/cartidpp/20.png",
+    "content": "Sample content"
+  },
+  {
+    "id": "barou_1",
+    "title": "Barou 1",
+    "image": "carti/1.png",
+    "content": "Sample content"
+  },
+  {
+    "id": "barou_2",
+    "title": "Barou 2",
+    "image": "carti/2.png",
+    "content": "Sample content"
+  },
+  {
+    "id": "not_1",
+    "title": "Notariat 1",
+    "image": "carti/cartidpc/1.png",
+    "content": "Sample content"
+  },
+  {
+    "id": "sng_1",
+    "title": "SNG 1",
+    "image": "carti/cartidp/11.png",
+    "content": "Sample content"
+  },
+  {
+    "id": "sj_1",
+    "title": "StartJuris 1",
+    "image": "carti/default.png",
+    "content": "Sample content"
   }
 ]

--- a/dashbord-react/src/BookEditor.tsx
+++ b/dashbord-react/src/BookEditor.tsx
@@ -1,0 +1,75 @@
+import React, { useState } from 'react';
+import ReactQuill from 'react-quill';
+
+export interface Book {
+  id: string;
+  title: string;
+  image: string;
+  content: string;
+}
+
+interface EditorProps {
+  book: Book;
+  onSave: (b: Book) => void;
+  onCancel: () => void;
+}
+
+const modules = {
+  toolbar: [
+    [{ font: [] }],
+    [{ header: [1, 2, 3, false] }],
+    ['bold', 'italic', 'underline', 'strike'],
+    [{ color: [] }, { background: [] }],
+    [{ list: 'ordered' }, { list: 'bullet' }],
+    ['link', 'image'],
+    ['clean']
+  ]
+};
+
+const formats = [
+  'header', 'font',
+  'bold', 'italic', 'underline', 'strike',
+  'color', 'background',
+  'list', 'bullet',
+  'link', 'image'
+];
+
+export default function BookEditor({ book, onSave, onCancel }: EditorProps) {
+  const [form, setForm] = useState({ ...book });
+
+  const save = () => {
+    onSave(form);
+  };
+
+  return (
+    <div className="p-6 space-y-4">
+      <button className="text-blue-600" onClick={onCancel}>&larr; Back</button>
+      <input
+        className="w-full border p-2 rounded"
+        value={form.title}
+        onChange={e => setForm({ ...form, title: e.target.value })}
+        placeholder="Title"
+      />
+      <input
+        className="w-full border p-2 rounded"
+        value={form.image}
+        onChange={e => setForm({ ...form, image: e.target.value })}
+        placeholder="Image URL"
+      />
+      <ReactQuill
+        theme="snow"
+        modules={modules}
+        formats={formats}
+        value={form.content}
+        onChange={v => setForm({ ...form, content: v })}
+        style={{ height: '70vh' }}
+      />
+      <button
+        className="px-4 py-2 bg-blue-600 text-white rounded"
+        onClick={save}
+      >
+        Save
+      </button>
+    </div>
+  );
+}

--- a/lib/pages/poveste_page.dart
+++ b/lib/pages/poveste_page.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
+import 'package:flutter_html/flutter_html.dart';
+import 'package:flutter_html/style.dart';
 
 class PovesterePage extends StatefulWidget {
   final String titlu;
@@ -89,14 +91,17 @@ class _PovesteRePageState extends State<PovesterePage> with TickerProviderStateM
   }
 
   Widget _buildContent() {
-    return SelectableText(
-      widget.continut,
-      style: TextStyle(
-        fontSize: _fontSize,
-        height: _lineHeight,
-        color: _textColor,
-        fontFamily: _fontFamily,
-      ),
+    return Html(
+      data: widget.continut,
+      style: {
+        "body": Style(
+          fontSize: FontSize(_fontSize),
+          lineHeight: LineHeight(_lineHeight),
+          color: _textColor,
+          fontFamily: _fontFamily,
+          backgroundColor: _backgroundColor,
+        ),
+      },
     );
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,6 +28,7 @@ dependencies:
   flutter_markdown: ^0.6.20
   scrollable_positioned_list: ^0.3.8
   flutter_highlight: ^0.7.0
+  flutter_html: ^3.0.0
   rive: ^0.12.4
   flutter_slidable: ^4.0.0
   flutter_staggered_animations: ^1.1.1


### PR DESCRIPTION
## Summary
- add BookEditor component for full-page editing with rich toolbar
- show more book categories in the React dashboard
- open books in the new editor page
- add initial books for new categories
- render HTML in Flutter reading page using `flutter_html`
- include `flutter_html` dependency

## Testing
- `flutter pub get` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684160c447288323bf8e56ad06cbc87d