### PR TITLE
Enable adding and deleting books from dashboard

### DIFF
--- a/dashbord-react/src/BookEditor.tsx
+++ b/dashbord-react/src/BookEditor.tsx
@@ -36,6 +36,27 @@ const formats = [
 
 export default function BookEditor({ book, onSave, onCancel }: EditorProps) {
   const [form, setForm] = useState({ ...book });
+  const [uploading, setUploading] = useState(false);
+
+  const handleFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const fd = new FormData();
+    fd.append('image', file);
+    setUploading(true);
+    try {
+      const res = await fetch('/api/books/upload-image', {
+        method: 'POST',
+        body: fd,
+      });
+      const data = await res.json();
+      if (data.url) {
+        setForm({ ...form, image: data.url });
+      }
+    } finally {
+      setUploading(false);
+    }
+  };
 
   const save = () => {
     onSave(form);
@@ -50,12 +71,19 @@ export default function BookEditor({ book, onSave, onCancel }: EditorProps) {
         onChange={e => setForm({ ...form, title: e.target.value })}
         placeholder="Title"
       />
-      <input
-        className="w-full border p-2 rounded"
-        value={form.image}
-        onChange={e => setForm({ ...form, image: e.target.value })}
-        placeholder="Image URL"
-      />
+      <div className="space-y-2">
+        <input
+          className="w-full border p-2 rounded"
+          value={form.image}
+          onChange={e => setForm({ ...form, image: e.target.value })}
+          placeholder="Image URL"
+        />
+        <input type="file" accept="image/*" onChange={handleFile} />
+        {uploading && <div className="text-sm text-gray-500">Uploading...</div>}
+        {form.image && (
+          <img src={form.image} alt="preview" className="w-32" />
+        )}
+      </div>
       <ReactQuill
         theme="snow"
         modules={modules}


### PR DESCRIPTION
## Summary
- support uploading book images in Go backend
- allow creating/deleting books from Materie section
- add image upload and preview to book editor

## Testing
- `npm run build`
- `go vet ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684163cc5bcc8323ba198c7e4064c47e