### PR TITLE
Improve book cards layout

### DIFF
--- a/lib/pages/materie/admiterebarou.dart
+++ b/lib/pages/materie/admiterebarou.dart
@@ -42,19 +42,21 @@ class AdmitereBarou extends StatelessWidget {
               children: [
                 SizedBox(
                   height: imageHeight,
-                  child: AspectRatio(
-                    aspectRatio: aspectRatio,
-                    child: Image.asset(
-                      'assets/carti/${_bookIndices[index]}.png',
-                      fit: BoxFit.contain,
-                      errorBuilder: (_, __, ___) => Container(
-                        color: Colors.grey.shade200,
-                        alignment: Alignment.center,
-                        child: const Icon(Icons.broken_image, size: 40),
+                  child: ClipRRect(
+                    borderRadius: BorderRadius.circular(12),
+                    child: AspectRatio(
+                      aspectRatio: aspectRatio,
+                      child: Image.asset(
+                        'assets/carti/${_bookIndices[index]}.png',
+                        fit: BoxFit.contain,
+                        errorBuilder: (_, __, ___) => Container(
+                          color: Colors.grey.shade200,
+                          alignment: Alignment.center,
+                          child: const Icon(Icons.broken_image, size: 40),
+                        ),
                       ),
                     ),
                   ),
-                ),
                 const SizedBox(height: 6),
                 SizedBox(
                   height: 16,

--- a/lib/pages/materie/admitereinm.dart
+++ b/lib/pages/materie/admitereinm.dart
@@ -42,19 +42,21 @@ class AdmitereINM extends StatelessWidget {
               children: [
                 SizedBox(
                   height: imageHeight,
-                  child: AspectRatio(
-                    aspectRatio: aspectRatio,
-                    child: Image.asset(
-                      'assets/carti/cartidpp/${_bookIndices[index]}.png',
-                      fit: BoxFit.contain,
-                      errorBuilder: (_, __, ___) => Container(
-                        color: Colors.grey.shade200,
-                        alignment: Alignment.center,
-                        child: const Icon(Icons.broken_image, size: 40),
+                  child: ClipRRect(
+                    borderRadius: BorderRadius.circular(12),
+                    child: AspectRatio(
+                      aspectRatio: aspectRatio,
+                      child: Image.asset(
+                        'assets/carti/cartidpp/${_bookIndices[index]}.png',
+                        fit: BoxFit.contain,
+                        errorBuilder: (_, __, ___) => Container(
+                          color: Colors.grey.shade200,
+                          alignment: Alignment.center,
+                          child: const Icon(Icons.broken_image, size: 40),
+                        ),
                       ),
                     ),
                   ),
-                ),
                 const SizedBox(height: 6),
                 SizedBox(
                   height: 16,

--- a/lib/pages/materie/admiterenotariat.dart
+++ b/lib/pages/materie/admiterenotariat.dart
@@ -42,19 +42,21 @@ class AdmitereNotariat extends StatelessWidget {
               children: [
                 SizedBox(
                   height: imageHeight,
-                  child: AspectRatio(
-                    aspectRatio: aspectRatio,
-                    child: Image.asset(
-                      'assets/carti/cartidpc/${_bookIndices[index]}.png',
-                      fit: BoxFit.contain,
-                      errorBuilder: (_, __, ___) => Container(
-                        color: Colors.grey.shade200,
-                        alignment: Alignment.center,
-                        child: const Icon(Icons.broken_image, size: 40),
+                  child: ClipRRect(
+                    borderRadius: BorderRadius.circular(12),
+                    child: AspectRatio(
+                      aspectRatio: aspectRatio,
+                      child: Image.asset(
+                        'assets/carti/cartidpc/${_bookIndices[index]}.png',
+                        fit: BoxFit.contain,
+                        errorBuilder: (_, __, ___) => Container(
+                          color: Colors.grey.shade200,
+                          alignment: Alignment.center,
+                          child: const Icon(Icons.broken_image, size: 40),
+                        ),
                       ),
                     ),
                   ),
-                ),
                 const SizedBox(height: 6),
                 SizedBox(
                   height: 16,

--- a/lib/pages/materie/admiteresng.dart
+++ b/lib/pages/materie/admiteresng.dart
@@ -42,19 +42,21 @@ class AdmitereSNG extends StatelessWidget {
               children: [
                 SizedBox(
                   height: imageHeight,
-                  child: AspectRatio(
-                    aspectRatio: aspectRatio,
-                    child: Image.asset(
-                      'assets/carti/cartidp/${_bookIndices[index]}.png',
-                      fit: BoxFit.contain,
-                      errorBuilder: (_, __, ___) => Container(
-                        color: Colors.grey.shade200,
-                        alignment: Alignment.center,
-                        child: const Icon(Icons.broken_image, size: 40),
+                  child: ClipRRect(
+                    borderRadius: BorderRadius.circular(12),
+                    child: AspectRatio(
+                      aspectRatio: aspectRatio,
+                      child: Image.asset(
+                        'assets/carti/cartidp/${_bookIndices[index]}.png',
+                        fit: BoxFit.contain,
+                        errorBuilder: (_, __, ___) => Container(
+                          color: Colors.grey.shade200,
+                          alignment: Alignment.center,
+                          child: const Icon(Icons.broken_image, size: 40),
+                        ),
                       ),
                     ),
                   ),
-                ),
                 const SizedBox(height: 6),
                 SizedBox(
                   height: 16,

--- a/lib/pages/materie/carticivil.dart
+++ b/lib/pages/materie/carticivil.dart
@@ -33,8 +33,9 @@ class CartiCivil extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    const cardHeight = 270.0;
     return Container(
-      height: 320,
+      height: cardHeight,
       margin: const EdgeInsets.only(top: 16),
       child: ListView.builder(
         scrollDirection: Axis.horizontal,
@@ -78,36 +79,55 @@ class CartiCivil extends StatelessWidget {
                   crossAxisAlignment: CrossAxisAlignment.stretch,
                   children: [
                     ClipRRect(
-                      borderRadius: const BorderRadius.vertical(
-                        top: Radius.circular(12),
-                      ),
+                      borderRadius: BorderRadius.circular(12),
                       child: AspectRatio(
                         aspectRatio: 0.75,
                         child: _buildImage(carte.image),
                       ),
                     ),
+                    const SizedBox(height: 8),
                     Padding(
-                      padding: const EdgeInsets.all(12),
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Text(
-                            carte.title,
-                            style: const TextStyle(
-                              fontSize: 12,
-                              fontWeight: FontWeight.w600,
-                              color: Colors.black87,
+                      padding: const EdgeInsets.symmetric(horizontal: 8),
+                      child: Text(
+                        carte.title,
+                        style: const TextStyle(
+                          fontSize: 12,
+                          fontWeight: FontWeight.w600,
+                          color: Colors.black87,
+                        ),
+                        maxLines: 2,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                    const SizedBox(height: 8),
+                    Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 8),
+                      child: SizedBox(
+                        height: 6,
+                        child: Stack(
+                          alignment: Alignment.centerLeft,
+                          children: [
+                            Container(
+                              decoration: BoxDecoration(
+                                color: Colors.grey.shade200,
+                                borderRadius: BorderRadius.circular(3),
+                              ),
                             ),
-                            maxLines: 2,
-                            overflow: TextOverflow.ellipsis,
-                          ),
-                          const SizedBox(height: 8),
-                          LinearProgressIndicator(
-                            value: 0.0,
-                            backgroundColor: Colors.grey.shade200,
-                            color: Colors.blue,
-                          ),
-                        ],
+                            FractionallySizedBox(
+                              widthFactor: 0.0,
+                              child: Container(
+                                decoration: const BoxDecoration(
+                                  gradient: LinearGradient(
+                                    colors: [Color(0xFF7CC4A2), Color(0xFFB8D8A0)],
+                                    begin: Alignment.centerLeft,
+                                    end: Alignment.centerRight,
+                                  ),
+                                  borderRadius: BorderRadius.all(Radius.circular(3)),
+                                ),
+                              ),
+                            ),
+                          ],
+                        ),
                       ),
                     ),
                   ],

--- a/lib/pages/materie/cartidp.dart
+++ b/lib/pages/materie/cartidp.dart
@@ -33,8 +33,9 @@ class CartiDP extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    const cardHeight = 270.0;
     return Container(
-      height: 320,
+      height: cardHeight,
       margin: const EdgeInsets.only(top: 16),
       child: ListView.builder(
         scrollDirection: Axis.horizontal,
@@ -78,36 +79,55 @@ class CartiDP extends StatelessWidget {
                   crossAxisAlignment: CrossAxisAlignment.stretch,
                   children: [
                     ClipRRect(
-                      borderRadius: const BorderRadius.vertical(
-                        top: Radius.circular(12),
-                      ),
+                      borderRadius: BorderRadius.circular(12),
                       child: AspectRatio(
                         aspectRatio: 0.75,
                         child: _buildImage(carte.image),
                       ),
                     ),
+                    const SizedBox(height: 8),
                     Padding(
-                      padding: const EdgeInsets.all(12),
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Text(
-                            carte.title,
-                            style: const TextStyle(
-                              fontSize: 12,
-                              fontWeight: FontWeight.w600,
-                              color: Colors.black87,
+                      padding: const EdgeInsets.symmetric(horizontal: 8),
+                      child: Text(
+                        carte.title,
+                        style: const TextStyle(
+                          fontSize: 12,
+                          fontWeight: FontWeight.w600,
+                          color: Colors.black87,
+                        ),
+                        maxLines: 2,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                    const SizedBox(height: 8),
+                    Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 8),
+                      child: SizedBox(
+                        height: 6,
+                        child: Stack(
+                          alignment: Alignment.centerLeft,
+                          children: [
+                            Container(
+                              decoration: BoxDecoration(
+                                color: Colors.grey.shade200,
+                                borderRadius: BorderRadius.circular(3),
+                              ),
                             ),
-                            maxLines: 2,
-                            overflow: TextOverflow.ellipsis,
-                          ),
-                          const SizedBox(height: 8),
-                          LinearProgressIndicator(
-                            value: 0.0,
-                            backgroundColor: Colors.grey.shade200,
-                            color: Colors.blue,
-                          ),
-                        ],
+                            FractionallySizedBox(
+                              widthFactor: 0.0,
+                              child: Container(
+                                decoration: const BoxDecoration(
+                                  gradient: LinearGradient(
+                                    colors: [Color(0xFF7CC4A2), Color(0xFFB8D8A0)],
+                                    begin: Alignment.centerLeft,
+                                    end: Alignment.centerRight,
+                                  ),
+                                  borderRadius: BorderRadius.all(Radius.circular(3)),
+                                ),
+                              ),
+                            ),
+                          ],
+                        ),
                       ),
                     ),
                   ],

--- a/lib/pages/materie/cartidpc.dart
+++ b/lib/pages/materie/cartidpc.dart
@@ -33,8 +33,9 @@ class CartiDPC extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    const cardHeight = 270.0;
     return Container(
-      height: 320,
+      height: cardHeight,
       margin: const EdgeInsets.only(top: 16),
       child: ListView.builder(
         scrollDirection: Axis.horizontal,
@@ -78,36 +79,55 @@ class CartiDPC extends StatelessWidget {
                   crossAxisAlignment: CrossAxisAlignment.stretch,
                   children: [
                     ClipRRect(
-                      borderRadius: const BorderRadius.vertical(
-                        top: Radius.circular(12),
-                      ),
+                      borderRadius: BorderRadius.circular(12),
                       child: AspectRatio(
                         aspectRatio: 0.75,
                         child: _buildImage(carte.image),
                       ),
                     ),
+                    const SizedBox(height: 8),
                     Padding(
-                      padding: const EdgeInsets.all(12),
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Text(
-                            carte.title,
-                            style: const TextStyle(
-                              fontSize: 12,
-                              fontWeight: FontWeight.w600,
-                              color: Colors.black87,
+                      padding: const EdgeInsets.symmetric(horizontal: 8),
+                      child: Text(
+                        carte.title,
+                        style: const TextStyle(
+                          fontSize: 12,
+                          fontWeight: FontWeight.w600,
+                          color: Colors.black87,
+                        ),
+                        maxLines: 2,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                    const SizedBox(height: 8),
+                    Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 8),
+                      child: SizedBox(
+                        height: 6,
+                        child: Stack(
+                          alignment: Alignment.centerLeft,
+                          children: [
+                            Container(
+                              decoration: BoxDecoration(
+                                color: Colors.grey.shade200,
+                                borderRadius: BorderRadius.circular(3),
+                              ),
                             ),
-                            maxLines: 2,
-                            overflow: TextOverflow.ellipsis,
-                          ),
-                          const SizedBox(height: 8),
-                          LinearProgressIndicator(
-                            value: 0.0,
-                            backgroundColor: Colors.grey.shade200,
-                            color: Colors.blue,
-                          ),
-                        ],
+                            FractionallySizedBox(
+                              widthFactor: 0.0,
+                              child: Container(
+                                decoration: const BoxDecoration(
+                                  gradient: LinearGradient(
+                                    colors: [Color(0xFF7CC4A2), Color(0xFFB8D8A0)],
+                                    begin: Alignment.centerLeft,
+                                    end: Alignment.centerRight,
+                                  ),
+                                  borderRadius: BorderRadius.all(Radius.circular(3)),
+                                ),
+                              ),
+                            ),
+                          ],
+                        ),
                       ),
                     ),
                   ],

--- a/lib/pages/materie/cartidpp.dart
+++ b/lib/pages/materie/cartidpp.dart
@@ -33,8 +33,9 @@ class CartiDPP extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    const cardHeight = 270.0;
     return Container(
-      height: 320,
+      height: cardHeight,
       margin: const EdgeInsets.only(top: 16),
       child: ListView.builder(
         scrollDirection: Axis.horizontal,
@@ -78,36 +79,55 @@ class CartiDPP extends StatelessWidget {
                   crossAxisAlignment: CrossAxisAlignment.stretch,
                   children: [
                     ClipRRect(
-                      borderRadius: const BorderRadius.vertical(
-                        top: Radius.circular(12),
-                      ),
+                      borderRadius: BorderRadius.circular(12),
                       child: AspectRatio(
                         aspectRatio: 0.75,
                         child: _buildImage(carte.image),
                       ),
                     ),
+                    const SizedBox(height: 8),
                     Padding(
-                      padding: const EdgeInsets.all(12),
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Text(
-                            carte.title,
-                            style: const TextStyle(
-                              fontSize: 12,
-                              fontWeight: FontWeight.w600,
-                              color: Colors.black87,
+                      padding: const EdgeInsets.symmetric(horizontal: 8),
+                      child: Text(
+                        carte.title,
+                        style: const TextStyle(
+                          fontSize: 12,
+                          fontWeight: FontWeight.w600,
+                          color: Colors.black87,
+                        ),
+                        maxLines: 2,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                    const SizedBox(height: 8),
+                    Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 8),
+                      child: SizedBox(
+                        height: 6,
+                        child: Stack(
+                          alignment: Alignment.centerLeft,
+                          children: [
+                            Container(
+                              decoration: BoxDecoration(
+                                color: Colors.grey.shade200,
+                                borderRadius: BorderRadius.circular(3),
+                              ),
                             ),
-                            maxLines: 2,
-                            overflow: TextOverflow.ellipsis,
-                          ),
-                          const SizedBox(height: 8),
-                          LinearProgressIndicator(
-                            value: 0.0,
-                            backgroundColor: Colors.grey.shade200,
-                            color: Colors.blue,
-                          ),
-                        ],
+                            FractionallySizedBox(
+                              widthFactor: 0.0,
+                              child: Container(
+                                decoration: const BoxDecoration(
+                                  gradient: LinearGradient(
+                                    colors: [Color(0xFF7CC4A2), Color(0xFFB8D8A0)],
+                                    begin: Alignment.centerLeft,
+                                    end: Alignment.centerRight,
+                                  ),
+                                  borderRadius: BorderRadius.all(Radius.circular(3)),
+                                ),
+                              ),
+                            ),
+                          ],
+                        ),
                       ),
                     ),
                   ],

--- a/lib/pages/materie/colectiastartjuris.dart
+++ b/lib/pages/materie/colectiastartjuris.dart
@@ -63,19 +63,21 @@ class ColectiaStartJuris extends StatelessWidget {
               children: [
                 SizedBox(
                   height: imageHeight,
-                  child: AspectRatio(
-                    aspectRatio: aspectRatio,
-                    child: Image.asset(
-                      _bookData[index]['path'],
-                      fit: BoxFit.contain,
-                      errorBuilder: (_, __, ___) => Container(
-                        color: Colors.grey.shade200,
-                        alignment: Alignment.center,
-                        child: const Icon(Icons.broken_image, size: 40),
+                  child: ClipRRect(
+                    borderRadius: BorderRadius.circular(12),
+                    child: AspectRatio(
+                      aspectRatio: aspectRatio,
+                      child: Image.asset(
+                        _bookData[index]['path'],
+                        fit: BoxFit.contain,
+                        errorBuilder: (_, __, ___) => Container(
+                          color: Colors.grey.shade200,
+                          alignment: Alignment.center,
+                          child: const Icon(Icons.broken_image, size: 40),
+                        ),
                       ),
                     ),
                   ),
-                ),
                 const SizedBox(height: 6),
                 SizedBox(
                   height: 16,

--- a/lib/pages/materie/materie_page.dart
+++ b/lib/pages/materie/materie_page.dart
@@ -50,7 +50,7 @@ class _MateriePageState extends State<MateriePage> {
     // Height of each horizontal list item. This should match the card
     // height defined in the book widgets to avoid clipping the bottom
     // of the cards.
-    const imageHeight = 320.0;
+    const imageHeight = 270.0;
 
     return Scaffold(
       backgroundColor: Colors.white,


### PR DESCRIPTION
## Summary
- tweak book list item height in `materie_page`
- restyle book card widgets with rounded images and custom progress bars
- add rounded images on admission pages

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841740818188323afbc36c17ddf0176