### PR TITLE
Fix crash when selecting updated codes

### DIFF
--- a/dashbord-react/src/CodeEditor.tsx
+++ b/dashbord-react/src/CodeEditor.tsx
@@ -55,10 +55,22 @@ export default function CodeEditor() {
 
   useEffect(() => {
     fetch(`/api/codes/${selected}`)
-      .then(r => r.json())
+      .then(r => {
+        if (!r.ok) throw new Error('failed to load code');
+        return r.json();
+      })
       .then((data: ParsedCode) => {
-        setCode(data);
-        setJson(JSON.stringify(data, null, 2));
+        if (data && Array.isArray(data.books)) {
+          setCode(data);
+          setJson(JSON.stringify(data, null, 2));
+        } else {
+          setCode(null);
+          setJson('');
+        }
+      })
+      .catch(() => {
+        setCode(null);
+        setJson('');
       });
   }, [selected]);
 
@@ -181,7 +193,7 @@ export default function CodeEditor() {
         />
       ) : (
         <div className="space-y-2">
-          {code && code.books.map(b => renderBook(b))}
+          {code?.books?.map(b => renderBook(b))}
         </div>
       )}
       <button className="px-4 py-2 bg-blue-600 text-white rounded" onClick={save}>


### PR DESCRIPTION
## Summary
- add error handling when fetching codes
- guard rendering if code data missing

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6841a4498ddc83238df7c7f5a8933137