### PR TITLE
Fix React dashboard build base path

### DIFF
--- a/dashbord-react/README.md
+++ b/dashbord-react/README.md
@@ -26,5 +26,6 @@ npm run build
 
 This generates a `dist/` folder that the Go server exposes at
 `http://localhost:8080/controlpanel` when running `go run ./backend` from the
-project root.
+project root. The Vite configuration sets the `base` option to `/controlpanel/`
+so the built assets are served correctly from that path.
 

--- a/dashbord-react/vite.config.ts
+++ b/dashbord-react/vite.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
 export default defineConfig({
+  base: '/controlpanel/',
   plugins: [react()],
   publicDir: '../assets',
   server: {


### PR DESCRIPTION
## Summary
- fix React build path so assets load from `/controlpanel/`
- document new Vite base configuration

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6841ae65a7c4832381c19f172d94938f