### PR TITLE
Fix crash with parsed code retrieval

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -203,6 +203,11 @@ func preloadParsedCodes() {
 
 func getParsedCodeHandler(c *gin.Context) {
 	id := c.Param("id")
+	jsonPath := filepath.Join("..", "dashbord-react", fmt.Sprintf("code_%s.json", id))
+	if _, err := os.Stat(jsonPath); err == nil {
+		c.File(jsonPath)
+		return
+	}
 	pc, err := loadParsedCode(id)
 	if err != nil {
 		c.JSON(http.StatusNotFound, gin.H{"error": "code not found"})


### PR DESCRIPTION
## Summary
- serve pre-generated code JSON directly when available to avoid unnecessary memory use

## Testing
- `go build ./...`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6841ce211e0483238effba81243095bd