### PR TITLE
Fix token file paths

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -56,6 +56,8 @@ func detectRepoRoot() string {
 	return "."
 }
 
+var rootDir = detectRepoRoot()
+
 type User struct {
 	ID        string   `json:"id"`
 	Username  string   `json:"username"`
@@ -71,7 +73,7 @@ type User struct {
 var users = make(map[string]User)
 var tokens = make(map[string]string) // token -> username
 
-const tokensFile = "tokens.json"
+var tokensFile = filepath.Join(rootDir, "backend", "tokens.json")
 
 func loadTokens() {
 	data, err := os.ReadFile(tokensFile)
@@ -92,7 +94,7 @@ func saveTokens() {
 var mu sync.Mutex
 var userUtils = make(map[string]map[string]interface{})
 
-const userFile = "users.json"
+var userFile = filepath.Join(rootDir, "backend", "users.json")
 
 func loadUsers() {
 	data, err := os.ReadFile(userFile)
@@ -198,8 +200,6 @@ type SimpleCode struct {
 }
 
 var codes = make(map[string]*SimpleCode)
-
-var rootDir = detectRepoRoot()
 
 var codesFile = filepath.Join(rootDir, "dashbord-react", "codes.json")
 var codesTextDir = filepath.Join(rootDir, "backend", "codurileactualizate")

--- a/backend/readmedash.md
+++ b/backend/readmedash.md
@@ -11,4 +11,6 @@ This file documents changes made to improve the code editor and backend.
 - Added error checking for `bufio.Scanner` in `parseCodeFile` so parsing failures
   are reported.
 - The React `CodeEditor` now handles API errors and displays a loading state.
+- Token and user data files are saved relative to the repository root so the
+  backend can reload authentication info regardless of the working directory.
 


### PR DESCRIPTION
## Summary
- store `tokens.json` and `users.json` relative to repo root
- document change in readmedash.md

## Testing
- `go vet ./...` *(fails: forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6841d9b1fd5c8323bdc33f6d930b52cd