### PR TITLE
Fix typing for react-window callback

### DIFF
--- a/dashbord-react/src/CodeEditor.tsx
+++ b/dashbord-react/src/CodeEditor.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { FixedSizeList as List } from 'react-window';
+import { FixedSizeList as List, ListChildComponentProps } from 'react-window';
 
 const ITEM_HEIGHT = 180;
 
@@ -132,7 +132,7 @@ export default function CodeEditor() {
         itemSize={ITEM_HEIGHT}
         width={"100%"}
       >
-        {({ index, style }) => {
+        {({ index, style }: ListChildComponentProps) => {
           const a = sec.articles[index];
           return (
             <div style={style} key={a.id} className="border p-2 my-2 rounded">


### PR DESCRIPTION
## Summary
- fix TypeScript typing for react-window render function

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6841db0f7bf48323afd71db0e0f3946e