### PR TITLE
Fix code parsing buffering and add startup logs

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -253,6 +253,7 @@ func preloadParsedCodes() {
 		}
 		pc, err := parseCodeFile(info.path, id, info.title)
 		if err != nil {
+			fmt.Println("failed to parse", id, "-", err)
 			continue
 		}
 		pc.LastUpdated = time.Now().Format(time.RFC3339)
@@ -1086,6 +1087,7 @@ func getFollowingHandler(c *gin.Context) {
 }
 
 func main() {
+	fmt.Println("Using repository root:", rootDir)
 	loadUsers()
 	loadTokens()
 	loadCodes()

--- a/backend/parser.go
+++ b/backend/parser.go
@@ -72,6 +72,9 @@ func parseCodeFile(path, codeID, codeTitle string) (*ParsedCode, error) {
 	defer file.Close()
 
 	scanner := bufio.NewScanner(file)
+	// some articles can be quite long, so increase the scanner buffer
+	buf := make([]byte, 0, 64*1024)
+	scanner.Buffer(buf, 1024*1024)
 
 	bookRe := regexp.MustCompile(`(?i)^Cartea`)
 	titleRe := regexp.MustCompile(`(?i)^Titlul`)

--- a/backend/readmedash.md
+++ b/backend/readmedash.md
@@ -14,3 +14,8 @@ This file documents changes made to improve the code editor and backend.
 - Token and user data files are saved relative to the repository root so the
   backend can reload authentication info regardless of the working directory.
 
+## New in this attempt
+- Increased the buffer size in `parseCodeFile` to avoid errors on very long lines.
+- The backend now prints the detected repository root and reports parsing errors
+  when preloading code files to help diagnose missing content issues.
+


### PR DESCRIPTION
## Summary
- increase scanner buffer for large articles
- print repository root path and log parsing errors
- document latest changes

## Testing
- `go run test.go parser.go` (manual test to parse codulcivil.txt)

------
https://chatgpt.com/codex/tasks/task_e_6841de0824808323a6f3f3586f5e8db3