### PR TITLE
Fix dashboard logout by persisting login state

### DIFF
--- a/backend/readmedash.md
+++ b/backend/readmedash.md
@@ -19,3 +19,10 @@ This file documents changes made to improve the code editor and backend.
 - The backend now prints the detected repository root and reports parsing errors
   when preloading code files to help diagnose missing content issues.
 
+## Changes in this fix
+- The React dashboard now persists the login state in `localStorage`, ensuring
+  the admin remains logged in even if a page refresh occurs when loading the
+  code editor.
+- Added a small logout button which clears the stored flag so testing remains
+  simple.
+

--- a/dashbord-react/src/App.tsx
+++ b/dashbord-react/src/App.tsx
@@ -15,6 +15,7 @@ function Login({ onLogin }: LoginProps) {
     e.preventDefault();
     if (username === 'admin' && password === 'admin') {
       onLogin();
+      localStorage.setItem('logged', 'true');
     } else {
       alert('Invalid credentials');
     }
@@ -230,7 +231,11 @@ function NewsList({ items, onUpdate, onEdit }: NewsProps) {
   );
 }
 
-function Dashboard() {
+interface DashboardProps {
+  onLogout: () => void;
+}
+
+function Dashboard({ onLogout }: DashboardProps) {
   const [books, setBooks] = useState<Book[]>([]);
   const [news, setNews] = useState<NewsItem[]>([]);
   const [section, setSection] = useState('materie');
@@ -322,14 +327,42 @@ function Dashboard() {
   return (
     <div className="flex h-screen">
       <Sidebar active={section} onSelect={setSection} />
-      <div className="flex-1 overflow-y-auto p-6">{renderSection()}</div>
+      <div className="flex-1 overflow-y-auto p-6">
+        <div className="text-right mb-4">
+          <button
+            className="text-sm text-blue-600"
+            onClick={() => {
+              localStorage.removeItem('logged');
+              onLogout();
+            }}
+          >
+            Logout
+          </button>
+        </div>
+        {renderSection()}
+      </div>
     </div>
   );
 }
 
 function App() {
-  const [logged, setLogged] = useState(false);
-  return logged ? <Dashboard /> : <Login onLogin={() => setLogged(true)} />;
+  const [logged, setLogged] = useState(
+    () => localStorage.getItem('logged') === 'true'
+  );
+
+  useEffect(() => {
+    if (logged) {
+      localStorage.setItem('logged', 'true');
+    } else {
+      localStorage.removeItem('logged');
+    }
+  }, [logged]);
+
+  return logged ? (
+    <Dashboard onLogout={() => setLogged(false)} />
+  ) : (
+    <Login onLogin={() => setLogged(true)} />
+  );
 }
 
 export default App;


### PR DESCRIPTION
## Summary
- keep admin login state in `localStorage`
- add a logout button
- document the changes in `readmedash.md`

## Testing
- `npm install`
- `npm run build`
- `go vet ./...` *(fails: Forbidden while downloading mimetype)*
- `go build ./...` *(fails: Forbidden while downloading mimetype)*

------
https://chatgpt.com/codex/tasks/task_e_6841e0d253b88323a2876ca91fd33422