### PR TITLE
Fix dashboard logout issue

### DIFF
--- a/backend/readmedash.md
+++ b/backend/readmedash.md
@@ -35,3 +35,5 @@ This file documents changes made to improve the code editor and backend.
   logged in across refreshes and prevent unintended logouts when opening the
   code editor.
 
+## Final adjustment
+- The profile verification on app load now retains the stored token unless the server explicitly returns a 401 response. Network or server errors no longer force a logout, preventing the admin from being kicked out when opening the code editor.

--- a/dashbord-react/src/App.tsx
+++ b/dashbord-react/src/App.tsx
@@ -391,15 +391,18 @@ function App() {
     })
       .then((r) => {
         if (!r.ok) {
-          localStorage.removeItem('token');
-          setLogged(false);
+          if (r.status === 401) {
+            // remove the token only if the server reports it is invalid
+            localStorage.removeItem('token');
+            setLogged(false);
+          }
         } else {
           setLogged(true);
         }
       })
-      .catch(() => {
-        localStorage.removeItem('token');
-        setLogged(false);
+      .catch((err) => {
+        // network or server error should not immediately log the user out
+        console.error('profile check failed', err);
       });
   }, []);
 


### PR DESCRIPTION
## Summary
- keep stored token if `/api/profile` fails for reasons other than invalid token
- document update in `readmedash.md`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841e4b87af0832382728a7fd710bf2c