### PR TITLE
Fix article parsing and update docs

### DIFF
--- a/backend/parser.go
+++ b/backend/parser.go
@@ -283,14 +283,14 @@ func parseCodeFile(path, codeID, codeTitle string) (*ParsedCode, error) {
 			expectTitle = true
 		default:
 			if currentArticle != nil {
-				if noteRe.MatchString(line) {
-					currentArticle.Notes = append(currentArticle.Notes, line)
-				} else if refRe.MatchString(strings.ToLower(line)) || strings.HasPrefix(line, "(") {
-					currentArticle.References = append(currentArticle.References, line)
-				} else if expectTitle {
-					currentArticle.Title = line
-					expectTitle = false
-				} else {
+                               if noteRe.MatchString(line) {
+                                       currentArticle.Notes = append(currentArticle.Notes, line)
+                               } else if refRe.MatchString(strings.ToLower(line)) {
+                                       currentArticle.References = append(currentArticle.References, line)
+                               } else if expectTitle {
+                                       currentArticle.Title = line
+                                       expectTitle = false
+                               } else {
 					if currentArticle.Content != "" {
 						currentArticle.Content += "\n" + line
 					} else {

--- a/backend/readmedash.md
+++ b/backend/readmedash.md
@@ -44,3 +44,8 @@ This file documents changes made to improve the code editor and backend.
 ## Fix for null sections
 - Parser now initializes Books, CodeTitles, and Chapters with empty slices to prevent null arrays in JSON.
 - CodeEditor guards against missing arrays when rendering.
+
+## Article parsing tweak
+- Updated the parser to treat lines starting with parentheses as part of the article
+  content instead of references. This ensures every article correctly includes
+  its paragraphs when displayed in the dashboard.


### PR DESCRIPTION
## Summary
- fix parser so article paragraphs are saved as content rather than references
- document parser tweak in `readmedash.md`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841ece4c4208323834b665ff9b3efea