### PR TITLE
Fix duplication in CodeEditor

### DIFF
--- a/backend/readmedash.md
+++ b/backend/readmedash.md
@@ -54,3 +54,6 @@ This file documents changes made to improve the code editor and backend.
 - CodeEditor now renders the entire code hierarchy expanded using headings
   instead of collapsible `<details>` elements. Articles are listed directly
   without virtualization so the full text is visible.
+
+## Display fix
+- Removed the raw text preview from CodeEditor to avoid duplicate article content.

--- a/dashbord-react/src/CodeEditor.tsx
+++ b/dashbord-react/src/CodeEditor.tsx
@@ -48,7 +48,6 @@ export default function CodeEditor() {
   const [codes, setCodes] = useState<CodeInfo[]>([]);
   const [active, setActive] = useState("");
   const [structure, setStructure] = useState<ParsedCode | null>(null);
-  const [rawText, setRawText] = useState("");
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
 
@@ -87,13 +86,6 @@ export default function CodeEditor() {
       .finally(() => setLoading(false));
   }, [active]);
 
-  useEffect(() => {
-    if (!active) return;
-    fetch(`/api/code-text/${active}`)
-      .then((r) => (r.ok ? r.text() : Promise.reject("Failed to load text")))
-      .then(setRawText)
-      .catch(() => setRawText(""));
-  }, [active]);
 
   const updateArticle = (id: string, field: keyof Article, value: string) => {
     if (!structure) return;
@@ -213,11 +205,6 @@ export default function CodeEditor() {
       <div className="space-y-2">
         {(structure.books || []).map((b) => renderBook(b))}
       </div>
-      {rawText && (
-        <pre className="whitespace-pre-wrap p-2 bg-white border rounded text-sm">
-          {rawText}
-        </pre>
-      )}
       <button
         className="px-4 py-2 bg-blue-600 text-white rounded"
         onClick={save}


### PR DESCRIPTION
## Summary
- remove raw text preview from CodeEditor
- document fix in readmedash

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841f1a351c48323b27d6a32ac4104c1