### PR TITLE
Fix code editor display and parsing

### DIFF
--- a/backend/parser.go
+++ b/backend/parser.go
@@ -283,14 +283,20 @@ func parseCodeFile(path, codeID, codeTitle string) (*ParsedCode, error) {
 			expectTitle = true
 		default:
 			if currentArticle != nil {
-                               if noteRe.MatchString(line) {
-                                       currentArticle.Notes = append(currentArticle.Notes, line)
-                               } else if refRe.MatchString(strings.ToLower(line)) {
-                                       currentArticle.References = append(currentArticle.References, line)
-                               } else if expectTitle {
-                                       currentArticle.Title = line
-                                       expectTitle = false
-                               } else {
+				if strings.HasPrefix(line, "(") {
+					if currentArticle.Content != "" {
+						currentArticle.Content += "\n" + line
+					} else {
+						currentArticle.Content = line
+					}
+				} else if noteRe.MatchString(line) {
+					currentArticle.Notes = append(currentArticle.Notes, line)
+				} else if refRe.MatchString(strings.ToLower(line)) {
+					currentArticle.References = append(currentArticle.References, line)
+				} else if expectTitle {
+					currentArticle.Title = line
+					expectTitle = false
+				} else {
 					if currentArticle.Content != "" {
 						currentArticle.Content += "\n" + line
 					} else {

--- a/backend/readmedash.md
+++ b/backend/readmedash.md
@@ -57,3 +57,8 @@ This file documents changes made to improve the code editor and backend.
 
 ## Display fix
 - Removed the raw text preview from CodeEditor to avoid duplicate article content.
+
+## Editor UX update
+- Articles are shown read-only by default with a new **Edit** button on each one.
+- Clicking the button reveals input fields so updates are intentional and clearer.
+- Parser now adds lines starting with parentheses directly to the article text before checking for notes or references, ensuring all paragraphs appear.

--- a/dashbord-react/src/CodeEditor.tsx
+++ b/dashbord-react/src/CodeEditor.tsx
@@ -50,6 +50,7 @@ export default function CodeEditor() {
   const [structure, setStructure] = useState<ParsedCode | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
+  const [editingId, setEditingId] = useState<string | null>(null);
 
   useEffect(() => {
     setLoading(true);
@@ -129,27 +130,51 @@ export default function CodeEditor() {
     const articles = sec.articles || [];
     return (
       <div className="ml-4">
-        {articles.map((a) => (
-          <div key={a.id} className="border p-2 my-2 rounded">
-            <div className="flex space-x-2 mb-1">
-              <input
-                className="border p-1 w-16"
-                value={a.number}
-                onChange={(e) => updateArticle(a.id, "number", e.target.value)}
-              />
-              <input
-                className="border p-1 flex-1"
-                value={a.title}
-                onChange={(e) => updateArticle(a.id, "title", e.target.value)}
-              />
+        {articles.map((a) => {
+          const editing = editingId === a.id;
+          return (
+            <div key={a.id} className="border p-2 my-2 rounded">
+              {editing ? (
+                <>
+                  <div className="flex space-x-2 mb-1">
+                    <input
+                      className="border p-1 w-16"
+                      value={a.number}
+                      onChange={(e) => updateArticle(a.id, "number", e.target.value)}
+                    />
+                    <input
+                      className="border p-1 flex-1"
+                      value={a.title}
+                      onChange={(e) => updateArticle(a.id, "title", e.target.value)}
+                    />
+                  </div>
+                  <textarea
+                    className="border p-1 w-full text-sm"
+                    value={a.content}
+                    onChange={(e) => updateArticle(a.id, "content", e.target.value)}
+                  />
+                  <button
+                    className="mt-1 px-2 py-1 bg-blue-600 text-white rounded"
+                    onClick={() => setEditingId(null)}
+                  >
+                    Done
+                  </button>
+                </>
+              ) : (
+                <>
+                  <div className="font-semibold">{a.number} {a.title}</div>
+                  <pre className="whitespace-pre-wrap text-sm">{a.content}</pre>
+                  <button
+                    className="mt-1 px-2 py-1 bg-gray-200 rounded"
+                    onClick={() => setEditingId(a.id)}
+                  >
+                    Edit
+                  </button>
+                </>
+              )}
             </div>
-            <textarea
-              className="border p-1 w-full text-sm"
-              value={a.content}
-              onChange={(e) => updateArticle(a.id, "content", e.target.value)}
-            />
-          </div>
-        ))}
+          );
+        })}
         {(sec.subsections || []).map((s) => renderSection(s))}
       </div>
     );


### PR DESCRIPTION
## Summary
- parse lines starting with `(` as article content before note/reference checks
- show articles in CodeEditor read-only with an Edit button
- document the UX update in `readmedash.md`

## Testing
- `npm install`
- `npm run build`
- `go run main.go` *(fails: forbidden downloading module)*

------
https://chatgpt.com/codex/tasks/task_e_6841f359c3a4832392d39fd255012b78