### PR TITLE
Fix ModernCodeReader crash

### DIFF
--- a/backend/readmedash.md
+++ b/backend/readmedash.md
@@ -62,3 +62,9 @@ This file documents changes made to improve the code editor and backend.
 - Articles are shown read-only by default with a new **Edit** button on each one.
 - Clicking the button reveals input fields so updates are intentional and clearer.
 - Parser now adds lines starting with parentheses directly to the article text before checking for notes or references, ensuring all paragraphs appear.
+
+## Flutter reader fix
+- The `ModernCodeReader` screen now checks the API response type before casting
+  to a map and gracefully handles missing lists when rendering. This prevents
+  `List<dynamic>`/`String` cast errors when loading the parsed codes from the
+  dashboard.

--- a/lib/pages/modern_code_reader.dart
+++ b/lib/pages/modern_code_reader.dart
@@ -32,9 +32,16 @@ class _ModernCodeReaderState extends State<ModernCodeReader> {
       final res =
           await http.get(Uri.parse('$baseUrl/api/parsed-code/${widget.codeId}'));
       if (res.statusCode == 200) {
-        setState(() {
-          _code = jsonDecode(res.body);
-        });
+        final decoded = jsonDecode(res.body);
+        if (decoded is Map<String, dynamic>) {
+          setState(() {
+            _code = decoded;
+          });
+        } else {
+          setState(() {
+            _error = 'Invalid data format';
+          });
+        }
       } else {
         setState(() {
           _error = 'Failed to load code';
@@ -63,45 +70,51 @@ class _ModernCodeReaderState extends State<ModernCodeReader> {
                   ? const SizedBox()
                   : ListView(
                       padding: const EdgeInsets.all(16),
-                      children: _buildBooks(_code!['books'] as List<dynamic>),
+                      children: _buildBooks(
+                          _code!['books'] is List ? _code!['books'] as List : []),
                     ),
     );
   }
 
   List<Widget> _buildBooks(List<dynamic> books) {
     return books.map((b) {
+      final titles = b is Map && b['titles'] is List ? b['titles'] as List : [];
       return ExpansionTile(
-        title: Text(b['title']),
-        children: _buildTitles(b['titles'] as List<dynamic>),
+        title: Text('${b is Map ? b['title'] ?? '' : ''}'),
+        children: _buildTitles(titles),
       );
     }).toList();
   }
 
   List<Widget> _buildTitles(List<dynamic> titles) {
     return titles.map((t) {
+      final chapters = t is Map && t['chapters'] is List ? t['chapters'] as List : [];
       return ExpansionTile(
-        title: Text(t['title']),
-        children: _buildChapters(t['chapters'] as List<dynamic>),
+        title: Text('${t is Map ? t['title'] ?? '' : ''}'),
+        children: _buildChapters(chapters),
       );
     }).toList();
   }
 
   List<Widget> _buildChapters(List<dynamic> chapters) {
     return chapters.map((c) {
+      final secs = c is Map && c['sections'] is List ? c['sections'] as List : [];
       return ExpansionTile(
-        title: Text(c['title']),
-        children: _buildSections(c['sections'] as List<dynamic>),
+        title: Text('${c is Map ? c['title'] ?? '' : ''}'),
+        children: _buildSections(secs),
       );
     }).toList();
   }
 
   List<Widget> _buildSections(List<dynamic> sections) {
     return sections.map((s) {
+      final arts = s is Map && s['articles'] is List ? s['articles'] as List : [];
+      final subs = s is Map && s['subsections'] is List ? s['subsections'] as List : [];
       return ExpansionTile(
-        title: Text(s['title']),
+        title: Text('${s is Map ? s['title'] ?? '' : ''}'),
         children: [
-          ..._buildArticles(s['articles'] as List<dynamic>),
-          ..._buildSubsections(s['subsections'] as List<dynamic>),
+          ..._buildArticles(arts),
+          ..._buildSubsections(subs),
         ],
       );
     }).toList();
@@ -109,9 +122,10 @@ class _ModernCodeReaderState extends State<ModernCodeReader> {
 
   List<Widget> _buildSubsections(List<dynamic> subs) {
     return subs.map((s) {
+      final arts = s is Map && s['articles'] is List ? s['articles'] as List : [];
       return ExpansionTile(
-        title: Text(s['title']),
-        children: _buildArticles(s['articles'] as List<dynamic>),
+        title: Text('${s is Map ? s['title'] ?? '' : ''}'),
+        children: _buildArticles(arts),
       );
     }).toList();
   }
@@ -119,8 +133,8 @@ class _ModernCodeReaderState extends State<ModernCodeReader> {
   List<Widget> _buildArticles(List<dynamic> arts) {
     return arts.map((a) {
       return ListTile(
-        title: Text('Art. ${a['number']} ${a['title']}'),
-        subtitle: Text(a['content'] ?? ''),
+        title: Text('Art. ${a is Map ? a['number'] ?? '' : ''} ${a is Map ? a['title'] ?? '' : ''}'),
+        subtitle: Text(a is Map ? (a['content'] ?? '') : ''),
       );
     }).toList();
   }


### PR DESCRIPTION
## Summary
- handle invalid API response in `ModernCodeReader`
- guard against missing lists when rendering
- document the reader fix in `backend/readmedash.md`

## Testing
- `dart` and `flutter` commands were not available so formatting and tests could not be run

------
https://chatgpt.com/codex/tasks/task_e_684202d277f48323bae06e05a0289edd