### PR TITLE
Configure alias and integrate shadcn components

### DIFF
--- a/dashbord-react/package.json
+++ b/dashbord-react/package.json
@@ -8,10 +8,15 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "class-variance-authority": "^0.7.1",
+    "framer-motion": "^12.16.0",
+    "lucide-react": "^0.513.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-quill": "^2.0.0",
-    "react-window": "^1.8.7"
+    "react-window": "^1.8.7",
+    "shadcn": "^2.6.0",
+    "tailwind-merge": "^3.3.0"
   },
   "devDependencies": {
     "@types/react": "^18.2.0",

--- a/dashbord-react/src/CodeEditor.tsx
+++ b/dashbord-react/src/CodeEditor.tsx
@@ -1,123 +1,123 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState } from "react"
+import { Card, CardContent } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { motion, AnimatePresence } from "framer-motion"
 
 interface Article {
-  id: string;
-  number: string;
-  title: string;
-  content: string;
-  notes?: string[];
-  references?: string[];
+  id: string
+  number: string
+  title: string
+  content: string
+  notes?: string[]
+  references?: string[]
 }
 
 interface CodeSection {
-  id: string;
-  title: string;
-  subsections: CodeSection[];
-  articles: Article[];
+  id: string
+  title: string
+  subsections: CodeSection[]
+  articles: Article[]
 }
 
 interface Chapter {
-  id: string;
-  title: string;
-  sections: CodeSection[];
+  id: string
+  title: string
+  sections: CodeSection[]
 }
 
 interface CodeTitle {
-  id: string;
-  title: string;
-  chapters: Chapter[];
+  id: string
+  title: string
+  chapters: Chapter[]
 }
 
 interface Book {
-  id: string;
-  title: string;
-  titles: CodeTitle[];
+  id: string
+  title: string
+  titles: CodeTitle[]
 }
 
 interface ParsedCode {
-  id: string;
-  title: string;
-  books: Book[];
+  id: string
+  title: string
+  books: Book[]
 }
 
 interface CodeInfo {
-  id: string;
-  title: string;
-  lastUpdated: string;
+  id: string
+  title: string
+  lastUpdated: string
 }
 
 export default function CodeEditor() {
-  const [codes, setCodes] = useState<CodeInfo[]>([]);
-  const [active, setActive] = useState("");
-  const [structure, setStructure] = useState<ParsedCode | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState("");
-  const [editingId, setEditingId] = useState<string | null>(null);
+  const [codes, setCodes] = useState<CodeInfo[]>([])
+  const [active, setActive] = useState("")
+  const [structure, setStructure] = useState<ParsedCode | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState("")
+  const [editingId, setEditingId] = useState<string | null>(null)
 
   useEffect(() => {
-    setLoading(true);
+    setLoading(true)
     fetch("/api/codes")
       .then(async (r) => {
-        if (!r.ok) throw new Error("Failed to load codes");
-        return r.json();
+        if (!r.ok) throw new Error("Failed to load codes")
+        return r.json()
       })
       .then((list: CodeInfo[]) => {
-        setCodes(list);
-        if (list.length > 0) {
-          setActive(list[0].id);
-        }
+        setCodes(list)
+        if (list.length > 0) setActive(list[0].id)
       })
       .catch((err) => setError(err.message))
-      .finally(() => setLoading(false));
-  }, []);
+      .finally(() => setLoading(false))
+  }, [])
 
   useEffect(() => {
-    if (!active) return;
-    setLoading(true);
-    setError("");
-    setStructure(null);
+    if (!active) return
+    setLoading(true)
+    setError("")
+    setStructure(null)
     fetch(`/api/parsed-code/${active}`)
       .then(async (r) => {
-        const data = await r.json();
+        const data = await r.json()
         if (!r.ok || (data as any).error) {
-          throw new Error((data as any).error || "Failed to load");
+          throw new Error((data as any).error || "Failed to load")
         }
-        return data;
+        return data
       })
       .then((d: ParsedCode) => setStructure(d))
       .catch((err) => setError(err.message))
-      .finally(() => setLoading(false));
-  }, [active]);
-
+      .finally(() => setLoading(false))
+  }, [active])
 
   const updateArticle = (id: string, field: keyof Article, value: string) => {
-    if (!structure) return;
-    const walkSections = (secs: CodeSection[]) => {
-      for (const s of secs) {
-        for (const a of s.articles) {
-          if (a.id === id) {
-            (a as any)[field] = value;
-            return true;
+    if (!structure) return
+    const walk = (sections: CodeSection[]): boolean => {
+      for (const sec of sections) {
+        for (const art of sec.articles) {
+          if (art.id === id) {
+            ;(art as any)[field] = value
+            return true
           }
         }
-        if (walkSections(s.subsections)) return true;
+        if (walk(sec.subsections)) return true
       }
-      return false;
-    };
+      return false
+    }
     for (const b of structure.books || []) {
       for (const t of b.titles || []) {
         for (const ch of t.chapters || []) {
-          if (walkSections(ch.sections || [])) {
-            setStructure({ ...structure });
-            return;
+          if (walk(ch.sections || [])) {
+            setStructure({ ...structure })
+            return
           }
         }
       }
     }
-  };
+  }
 
   const save = () => {
-    if (!structure) return;
+    if (!structure) return
     fetch(`/api/save-parsed-code/${structure.id}`, {
       method: "POST",
       headers: {
@@ -125,152 +125,138 @@ export default function CodeEditor() {
         Authorization: `Bearer ${localStorage.getItem("token") || ""}`,
       },
       body: JSON.stringify(structure),
-    });
-  };
+    })
+  }
 
-  const renderArticles = (sec: CodeSection) => {
-    const articles = sec.articles || [];
-    return (
-      <div className="ml-4">
-        {articles.map((a) => {
-          const editing = editingId === a.id;
-          return (
-            <div key={a.id} className="py-1 flex items-start">
-              <div className="flex-1 text-sm space-y-1">
-                {editing ? (
-                  <>
-                    <div className="flex space-x-2">
-                      <input
-                        className="border p-1 w-16"
-                        value={a.number}
-                        onChange={(e) => updateArticle(a.id, "number", e.target.value)}
-                      />
-                      <input
-                        className="border p-1 flex-1"
-                        value={a.title}
-                        onChange={(e) => updateArticle(a.id, "title", e.target.value)}
-                      />
-                    </div>
-                    <textarea
-                      className="p-1 w-full"
-                      value={a.content}
-                      onChange={(e) => updateArticle(a.id, "content", e.target.value)}
+  const renderArticles = (sec: CodeSection) => (
+    <div className="ml-4 space-y-2">
+      {sec.articles.map((a) => {
+        const editing = editingId === a.id
+        return (
+          <Card key={a.id} className="p-2">
+            <CardContent className="space-y-2">
+              {editing ? (
+                <>
+                  <div className="flex space-x-2">
+                    <input
+                      className="border p-1 w-16"
+                      value={a.number}
+                      onChange={(e) => updateArticle(a.id, "number", e.target.value)}
                     />
-                    {a.notes &&
-                      a.notes.map((n, idx) => (
-                        <div key={idx} className="border border-gray-300 bg-gray-50 p-2 text-xs">
-                          {n}
-                        </div>
-                      ))}
-                    {a.references &&
-                      a.references.map((r, idx) => (
-                        <div key={`ref-${idx}`} className="border border-gray-300 bg-gray-50 p-2 text-xs">
-                          {r}
-                        </div>
-                      ))}
-                  </>
-                ) : (
-                  <>
-                    <div className="font-semibold">
-                      {`Articolul ${a.number} - ${a.title}`}
-                    </div>
-                    <div className="whitespace-pre-wrap">{a.content}</div>
-                    {a.notes &&
-                      a.notes.map((n, idx) => (
-                        <div key={idx} className="border border-gray-300 bg-gray-50 p-2 text-xs">
-                          {n}
-                        </div>
-                      ))}
-                    {a.references &&
-                      a.references.map((r, idx) => (
-                        <div key={`ref-${idx}`} className="border border-gray-300 bg-gray-50 p-2 text-xs">
-                          {r}
-                        </div>
-                      ))}
-                  </>
-                )}
-              </div>
-              <div className="ml-2">
-                {editing ? (
-                  <button
-                    className="text-blue-600"
-                    onClick={() => {
-                      setEditingId(null);
-                      save();
-                    }}
-                  >
-                    Save
-                  </button>
-                ) : (
-                  <button className="text-blue-600" onClick={() => setEditingId(a.id)}>
-                    Edit
-                  </button>
-                )}
-              </div>
-            </div>
-          );
-        })}
-        {(sec.subsections || []).map((s) => renderSection(s))}
-      </div>
-    );
-  };
+                    <input
+                      className="border p-1 flex-1"
+                      value={a.title}
+                      onChange={(e) => updateArticle(a.id, "title", e.target.value)}
+                    />
+                  </div>
+                  <textarea
+                    className="w-full p-1 border"
+                    value={a.content}
+                    onChange={(e) => updateArticle(a.id, "content", e.target.value)}
+                  />
+                </>
+              ) : (
+                <>
+                  <div className="font-semibold">{`Articolul ${a.number} - ${a.title}`}</div>
+                  <div className="whitespace-pre-wrap">{a.content}</div>
+                </>
+              )}
 
-  const renderSection = (sec: CodeSection) => (
-    <div key={sec.id} className="ml-2">
-      <h5 className="font-semibold mt-4">{sec.title}</h5>
-      {renderArticles(sec)}
+              <AnimatePresence>
+                {(a.notes || []).map((n, idx) => (
+                  <motion.div
+                    key={idx}
+                    className="border border-gray-300 bg-gray-50 p-2 text-xs"
+                    initial={{ opacity: 0, y: -2 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    exit={{ opacity: 0, y: -2 }}
+                  >
+                    {n}
+                  </motion.div>
+                ))}
+                {(a.references || []).map((r, idx) => (
+                  <motion.div
+                    key={`ref-${idx}`}
+                    className="border border-gray-300 bg-gray-50 p-2 text-xs"
+                    initial={{ opacity: 0, y: -2 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    exit={{ opacity: 0, y: -2 }}
+                  >
+                    {r}
+                  </motion.div>
+                ))}
+              </AnimatePresence>
+              <div className="text-right">
+                {editing ? (
+                  <Button size="sm" onClick={() => { setEditingId(null); save(); }}>
+                    Save
+                  </Button>
+                ) : (
+                  <Button variant="ghost" size="sm" onClick={() => setEditingId(a.id)}>
+                    Edit
+                  </Button>
+                )}
+              </div>
+            </CardContent>
+          </Card>
+        )
+      })}
+      {sec.subsections.map((s) => (
+        <div key={s.id} className="ml-4">
+          <h5 className="font-semibold mt-4">{s.title}</h5>
+          {renderArticles(s)}
+        </div>
+      ))}
     </div>
-  );
+  )
 
   const renderChapter = (ch: Chapter) => (
     <div key={ch.id} className="ml-2">
       <h4 className="font-semibold mt-4">{ch.title}</h4>
-      {(ch.sections || []).map((sec) => renderSection(sec))}
+      {ch.sections.map((sec) => (
+        <div key={sec.id} className="ml-2">
+          <h5 className="font-semibold mt-4">{sec.title}</h5>
+          {renderArticles(sec)}
+        </div>
+      ))}
     </div>
-  );
+  )
 
   const renderTitle = (t: CodeTitle) => (
     <div key={t.id} className="ml-2">
       <h3 className="font-semibold mt-4">{t.title}</h3>
-      {(t.chapters || []).map((ch) => renderChapter(ch))}
+      {t.chapters.map((ch) => renderChapter(ch))}
     </div>
-  );
+  )
 
   const renderBook = (b: Book) => (
     <div key={b.id}>
       <h2 className="font-bold mt-6">{b.title}</h2>
-      {(b.titles || []).map((t) => renderTitle(t))}
+      {b.titles.map((t) => renderTitle(t))}
     </div>
-  );
+  )
 
-  if (loading) return <div>Loading...</div>;
-  if (error) return <div className="text-red-600">{error}</div>;
-  if (!structure) return <div>No data</div>;
+  if (loading) return <div>Loading...</div>
+  if (error) return <div className="text-red-600">{error}</div>
+  if (!structure) return <div>No data</div>
 
   return (
     <div className="space-y-4 font-sans text-sm">
       <div className="border-b mb-4 space-x-2">
         {codes.map((c) => (
-          <button
+          <Button
             key={c.id}
-            className={`px-4 py-2 rounded-t ${
-              active === c.id ? "bg-blue-600 text-white" : "bg-gray-200"
-            }`}
+            variant={active === c.id ? "default" : "secondary"}
             onClick={() => setActive(c.id)}
           >
             {c.title}
-          </button>
+          </Button>
         ))}
       </div>
       <div className="space-y-2">
-        {(structure.books || []).map((b) => renderBook(b))}
+        {structure.books.map((b) => renderBook(b))}
       </div>
-      <button
-        className="px-4 py-2 bg-blue-600 text-white rounded"
-        onClick={save}
-      >
-        Save
-      </button>
+      <Button onClick={save}>Save</Button>
     </div>
-  );
+  )
 }

--- a/dashbord-react/src/components/ui/button.tsx
+++ b/dashbord-react/src/components/ui/button.tsx
@@ -1,0 +1,49 @@
+import * as React from "react"
+import { VariantProps, cva } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        destructive: "bg-destructive text-destructive-foreground hover:bg-destructive/90",
+        outline: "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+        secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        ghost: "hover:bg-accent hover:text-accent-foreground",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default: "h-10 py-2 px-4",
+        sm: "h-9 rounded-md px-3",
+        lg: "h-11 rounded-md px-8",
+        icon: "h-10 w-10",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, ...props }, ref) => {
+    return (
+      <button
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Button.displayName = "Button"
+
+export { Button, buttonVariants }

--- a/dashbord-react/src/components/ui/card.tsx
+++ b/dashbord-react/src/components/ui/card.tsx
@@ -1,0 +1,57 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn("rounded-lg border bg-card text-card-foreground shadow-sm", className)}
+      {...props}
+    />
+  )
+)
+Card.displayName = "Card"
+
+const CardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn("flex flex-col space-y-1.5 p-6", className)} {...props} />
+  )
+)
+CardHeader.displayName = "CardHeader"
+
+const CardTitle = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h3
+    ref={ref}
+    className={cn("text-2xl font-semibold leading-none tracking-tight", className)}
+    {...props}
+  />
+))
+CardTitle.displayName = "CardTitle"
+
+const CardDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <p ref={ref} className={cn("text-sm text-muted-foreground", className)} {...props} />
+))
+CardDescription.displayName = "CardDescription"
+
+const CardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+  )
+)
+CardContent.displayName = "CardContent"
+
+const CardFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn("flex items-center p-6 pt-0", className)} {...props} />
+  )
+)
+CardFooter.displayName = "CardFooter"
+
+export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent }

--- a/dashbord-react/src/lib/utils.ts
+++ b/dashbord-react/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from "clsx"
+import { twMerge } from "tailwind-merge"
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}

--- a/dashbord-react/tsconfig.json
+++ b/dashbord-react/tsconfig.json
@@ -11,10 +11,14 @@
     "forceConsistentCasingInFileNames": true,
     "module": "ESNext",
     "moduleResolution": "Node",
+    "baseUrl": ".",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "paths": {
+      "@/*": ["src/*"]
+    }
   },
   "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]

--- a/dashbord-react/vite.config.ts
+++ b/dashbord-react/vite.config.ts
@@ -1,10 +1,16 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import path from 'path';
 
 export default defineConfig({
   base: '/controlpanel/',
   plugins: [react()],
   publicDir: '../assets',
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, 'src'),
+    },
+  },
   server: {
     open: false,
     fs: {


### PR DESCRIPTION
## Summary
- configure `@` alias in Vite and TypeScript
- add Shadcn-based UI components and helper
- replace `CodeEditor` with new version using the alias, Shadcn UI and framer-motion
- install framer-motion, shadcn, class-variance-authority, tailwind-merge and lucide-react

## Testing
- `npm run dev` *(fails: Non relative path error resolved; server starts)*

------
https://chatgpt.com/codex/tasks/task_e_6842912e364883238ea00c43cf6ccfe7