### PR TITLE
Improve note parsing and styling

### DIFF
--- a/dashbord-react/src/CodeEditor.tsx
+++ b/dashbord-react/src/CodeEditor.tsx
@@ -197,7 +197,7 @@ export default function CodeEditor() {
           ) : (
             <>
               <div className="font-semibold">{`Articolul ${a.number} - ${a.title}`}</div>
-              <div className="whitespace-pre-wrap">{a.content}</div>
+              <div className="whitespace-pre-wrap leading-snug">{a.content}</div>
             </>
           )}
 
@@ -205,7 +205,7 @@ export default function CodeEditor() {
             {(a.notes || []).map((n, idx) => (
               <motion.div
                 key={idx}
-                className="p-2 text-xs"
+                className="p-2 text-xs rounded bg-gradient-to-r from-yellow-50 to-blue-50"
                 initial={{ opacity: 0, y: -2 }}
                 animate={{ opacity: 1, y: 0 }}
                 exit={{ opacity: 0, y: -2 }}
@@ -216,7 +216,7 @@ export default function CodeEditor() {
             {(a.references || []).map((r, idx) => (
               <motion.div
                 key={`ref-${idx}`}
-                className="p-2 text-xs"
+                className="p-2 text-xs rounded bg-gradient-to-r from-yellow-50 to-blue-50"
                 initial={{ opacity: 0, y: -2 }}
                 animate={{ opacity: 1, y: 0 }}
                 exit={{ opacity: 0, y: -2 }}


### PR DESCRIPTION
## Summary
- parse multi-line notes in `parser.go`
- style notes and references in `CodeEditor` with a gradient background and compact line height
- tighten article text line height

## Testing
- `go vet ./...` *(fails: gabriel-vasile/mimetype download forbidden)*
- `go build ./...` *(fails: gabriel-vasile/mimetype download forbidden)*
- `npm run build` in `dashbord-react` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842983081b483239c9340f4bdce66e9