### PR TITLE
Fix note parsing and layout improvements

### DIFF
--- a/dashbord-react/src/CodeEditor.tsx
+++ b/dashbord-react/src/CodeEditor.tsx
@@ -202,28 +202,26 @@ export default function CodeEditor() {
           )}
 
           <AnimatePresence>
-            {(a.notes || []).map((n, idx) => (
+            {(a.notes?.length || a.references?.length) ? (
               <motion.div
-                key={idx}
-                className="p-2 text-xs rounded bg-gradient-to-r from-yellow-50 to-blue-50"
+                key="notes"
+                className="p-2 text-xs rounded bg-gradient-to-r from-yellow-50 to-blue-50 space-y-1"
                 initial={{ opacity: 0, y: -2 }}
                 animate={{ opacity: 1, y: 0 }}
                 exit={{ opacity: 0, y: -2 }}
               >
-                {n}
+                {(a.notes || []).map((n, idx) => (
+                  <div key={idx} className="whitespace-pre-wrap leading-snug">
+                    {n}
+                  </div>
+                ))}
+                {(a.references || []).map((r, idx) => (
+                  <div key={`ref-${idx}`} className="whitespace-pre-wrap leading-snug">
+                    {r}
+                  </div>
+                ))}
               </motion.div>
-            ))}
-            {(a.references || []).map((r, idx) => (
-              <motion.div
-                key={`ref-${idx}`}
-                className="p-2 text-xs rounded bg-gradient-to-r from-yellow-50 to-blue-50"
-                initial={{ opacity: 0, y: -2 }}
-                animate={{ opacity: 1, y: 0 }}
-                exit={{ opacity: 0, y: -2 }}
-              >
-                {r}
-              </motion.div>
-            ))}
+            ) : null}
           </AnimatePresence>
           <div className="text-right">
             {editing ? (


### PR DESCRIPTION
## Summary
- avoid panic in parser when note appears outside of an article
- group article notes and references in a single gradient box

## Testing
- `go run test_parse.go parser.go` *(fails: main undeclared)*
- `go run test_parse.go parser.go` *(after fix)*

------
https://chatgpt.com/codex/tasks/task_e_68429a43fbb483238fac836d79f8b8e4