### PR TITLE
Remove notes and references from CodeEditor

### DIFF
--- a/dashbord-react/src/CodeEditor.tsx
+++ b/dashbord-react/src/CodeEditor.tsx
@@ -1,15 +1,13 @@
 import React, { useEffect, useState } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { motion, AnimatePresence } from "framer-motion";
+
 
 interface Article {
   id: string;
   number: string;
   title: string;
   content: string;
-  notes?: string[];
-  references?: string[];
 }
 
 interface CodeSection {
@@ -201,28 +199,6 @@ export default function CodeEditor() {
             </>
           )}
 
-          <AnimatePresence>
-            {(a.notes?.length || a.references?.length) ? (
-              <motion.div
-                key="notes"
-                className="p-2 text-xs rounded bg-gradient-to-r from-yellow-50 to-blue-50 space-y-1"
-                initial={{ opacity: 0, y: -2 }}
-                animate={{ opacity: 1, y: 0 }}
-                exit={{ opacity: 0, y: -2 }}
-              >
-                {(a.notes || []).map((n, idx) => (
-                  <div key={idx} className="whitespace-pre-wrap leading-snug">
-                    {n}
-                  </div>
-                ))}
-                {(a.references || []).map((r, idx) => (
-                  <div key={`ref-${idx}`} className="whitespace-pre-wrap leading-snug">
-                    {r}
-                  </div>
-                ))}
-              </motion.div>
-            ) : null}
-          </AnimatePresence>
           <div className="text-right">
             {editing ? (
               <Button


### PR DESCRIPTION
## Summary
- simplify `CodeEditor` by removing notes and references
- drop framer-motion usage
- keep clean layout for article structure

## Testing
- `npm install` in `dashbord-react`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6842a7b42fb08323a7caf431f6bcdeb5