### PR TITLE
Handle notes in RawCodeEditor

### DIFF
--- a/dashbord-react/src/RawCodeEditor.tsx
+++ b/dashbord-react/src/RawCodeEditor.tsx
@@ -115,6 +115,14 @@ export default function RawCodeEditor() {
             <>
               <div className="font-semibold">{`Articolul ${a.number} - ${a.title}`}</div>
               <div className="whitespace-pre-wrap leading-snug">{a.content}</div>
+              {a.notes.map((n, i) => (
+                <div
+                  key={i}
+                  className="border text-xs rounded p-1 mt-1 bg-gradient-to-r from-yellow-50 to-blue-50"
+                >
+                  {n}
+                </div>
+              ))}
             </>
           )}
           <div className="text-right">

--- a/dashbord-react/src/lib/parseCode.ts
+++ b/dashbord-react/src/lib/parseCode.ts
@@ -3,6 +3,7 @@ export interface Article {
   number: string;
   title: string;
   content: string;
+  notes: string[];
 }
 
 export interface CodeSection {
@@ -43,6 +44,8 @@ export function parseRawCode(text: string, id = "custom", title = "Cod personal"
   const sectionRe = /^Sec[tț]iunea/i;
   const subsectionRe = /^Subsec[tț]iunea/i;
   const articleRe = /^Articolul\s+(\d+)/i;
+  const noteRe = /^Not[aă]/i;
+  const amendRe = /^\(la\s.*|^\(/i;
 
   let bookOrder = 0;
   let titleOrder = 0;
@@ -75,6 +78,13 @@ export function parseRawCode(text: string, id = "custom", title = "Cod personal"
   for (let raw of lines) {
     const line = raw.trim();
     if (!line) continue;
+
+    if (noteRe.test(line) || amendRe.test(line)) {
+      if (currentArticle) {
+        currentArticle.notes.push(line);
+      }
+      continue;
+    }
 
     if (bookRe.test(line)) {
       finishArticle();
@@ -228,6 +238,7 @@ export function parseRawCode(text: string, id = "custom", title = "Cod personal"
         number: num,
         title: "",
         content: "",
+        notes: [],
       };
       expectTitle = true;
       continue;


### PR DESCRIPTION
## Summary
- add `notes` field to `Article` structures
- parse note/amendment lines when importing raw legal text
- show parsed notes below each article in `RawCodeEditor`

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842aec49a408323b4dcf1cd1a48145f