### PR TITLE
Refine raw code editor

### DIFF
--- a/dashbord-react/src/lib/parseCode.ts
+++ b/dashbord-react/src/lib/parseCode.ts
@@ -74,6 +74,13 @@ export function parseRawCode(text: string, id = "custom", title = "Cod personal"
 
   function finishArticle() {
     if (!currentArticle) return;
+    if (
+      currentArticle.content &&
+      !currentArticle.content.trim().startsWith("(") &&
+      !currentArticle.content.includes("\n")
+    ) {
+      currentArticle.content = `(1) ${currentArticle.content}`;
+    }
     if (currentSub) {
       currentSub.articles.push(currentArticle);
     } else if (currentSection) {


### PR DESCRIPTION
## Summary
- tweak parser to insert `(1)` when an article has a single paragraph
- redesign RawCodeEditor with tabs for each code
- add sub-tabs for edit vs published mode
- allow editing article notes in RawCodeEditor

## Testing
- `npm install`
- `npm run build`
- `go vet ./...` *(fails: Forbidden)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842b8fd24808323905adcbb9a7c5447