### PR TITLE
Add Codurile la zi page

### DIFF
--- a/dashbord-react/src/App.tsx
+++ b/dashbord-react/src/App.tsx
@@ -3,6 +3,7 @@ import BookEditor, { Book as BookType } from './BookEditor';
 import NewsEditor, { NewsItem } from './NewsEditor';
 import CodeEditor from './CodeEditor';
 import RawCodeEditor from './RawCodeEditor';
+import CodeTextTabs from './CodeTextTabs';
 
 interface LoginProps {
   onLogin: () => void;
@@ -67,6 +68,7 @@ const sections = [
   { key: 'materie', label: 'Materie', icon: 'menu_book' },
   { key: 'codes', label: 'Codurile actualizate', icon: 'library_books' },
   { key: 'codes2', label: 'Codurile 2', icon: 'description' },
+  { key: 'coduri_lazi', label: 'Codurile la zi', icon: 'article' },
   { key: 'noutati', label: 'Noutati', icon: 'feed' },
   { key: 'grile', label: 'Grile', icon: 'view_list' },
   { key: 'meciuri', label: 'Grile meciuri', icon: 'sports_esports' },
@@ -342,6 +344,9 @@ function Dashboard({ onLogout }: DashboardProps) {
     }
     if (section === 'codes2') {
       return <RawCodeEditor />;
+    }
+    if (section === 'coduri_lazi') {
+      return <CodeTextTabs />;
     }
     const s = sections.find((x) => x.key === section);
     return (

--- a/dashbord-react/src/CodeTextTabs.tsx
+++ b/dashbord-react/src/CodeTextTabs.tsx
@@ -1,0 +1,62 @@
+import React, { useEffect, useState } from 'react';
+import { Button } from '@/components/ui/button';
+
+interface CodeTab {
+  id: string;
+  label: string;
+}
+
+const codes: CodeTab[] = [
+  { id: 'civil', label: 'Codul civil' },
+  { id: 'penal', label: 'Codul penal' },
+  { id: 'proc_civil', label: 'Codul de procedura civila' },
+  { id: 'proc_penal', label: 'Codul de procedura penala' },
+];
+
+export default function CodeTextTabs() {
+  const [active, setActive] = useState<string>(codes[0].id);
+  const [texts, setTexts] = useState<Record<string, string>>({});
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    if (texts[active]) return;
+    setLoading(true);
+    setError('');
+    fetch(`/api/code-text/${active}`)
+      .then(async (r) => {
+        if (!r.ok) throw new Error('Failed to load');
+        return r.text();
+      })
+      .then((txt) => {
+        setTexts((t) => ({ ...t, [active]: txt }));
+      })
+      .catch((err: any) => {
+        setError(err.message || 'Error');
+      })
+      .finally(() => setLoading(false));
+  }, [active]);
+
+  return (
+    <div className="space-y-4">
+      <div className="border-b mb-4 space-x-2">
+        {codes.map((c) => (
+          <Button
+            key={c.id}
+            variant={active === c.id ? 'default' : 'secondary'}
+            onClick={() => setActive(c.id)}
+          >
+            {c.label}
+          </Button>
+        ))}
+      </div>
+      {loading ? (
+        <div>Loading...</div>
+      ) : error ? (
+        <div className="text-red-600">{error}</div>
+      ) : (
+        <pre className="whitespace-pre-wrap text-sm">{texts[active]}</pre>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a `CodeTextTabs` component for showing the text of each code in tabs
- integrate the new page in the dashboard sidebar

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6842c2af425083239d86e214cce8d8c9