### PR TITLE
Add filter for codurile la zi text

### DIFF
--- a/dashbord-react/src/CodeTextTabs.tsx
+++ b/dashbord-react/src/CodeTextTabs.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { Button } from '@/components/ui/button';
+import { filterCodeText } from './codurilelazi/filtru';
 
 interface CodeTab {
   id: string;
@@ -29,7 +30,8 @@ export default function CodeTextTabs() {
         return r.text();
       })
       .then((txt) => {
-        setTexts((t) => ({ ...t, [active]: txt }));
+        const filtered = filterCodeText(txt);
+        setTexts((t) => ({ ...t, [active]: filtered }));
       })
       .catch((err: any) => {
         setError(err.message || 'Error');

--- a/dashbord-react/src/codurilelazi/filtru.tsx
+++ b/dashbord-react/src/codurilelazi/filtru.tsx
@@ -1,0 +1,8 @@
+export function filterCodeText(text: string): string {
+  const lines = text.split(/\r?\n/);
+  const startIndex = lines.findIndex((line) =>
+    /^(titlul|partea|cartea|capitolul|articolul)/i.test(line.trim())
+  );
+  const sliced = startIndex >= 0 ? lines.slice(startIndex) : lines;
+  return sliced.join('\n').trim();
+}


### PR DESCRIPTION
## Summary
- add `filtru.tsx` utility that trims legal code headers
- use the filter in `CodeTextTabs` when fetching raw code

## Testing
- `npm -v`

------
https://chatgpt.com/codex/tasks/task_e_6842c4b23ddc8323b6e3cbbdab4b0a03