### PR TITLE
Adjust parsing and UI

### DIFF
--- a/backend/parser.go
+++ b/backend/parser.go
@@ -81,7 +81,7 @@ func parseCodeFile(path, codeID, codeTitle string) (*ParsedCode, error) {
 	chapterRe := regexp.MustCompile(`(?i)^Capitolul`)
 	sectionRe := regexp.MustCompile(`(?i)^Sec[tț]iunea`)
 	subsectionRe := regexp.MustCompile(`(?i)^Subsec[tț]iunea`)
-	articleRe := regexp.MustCompile(`(?i)^Articolul\s+(\d+)`)
+        articleRe := regexp.MustCompile(`(?i)^Articolul\s+(\d+)\s*(?:-\s*(.+))?$`)
 	noteRe := regexp.MustCompile(`(?i)^Not[aă]`)
 	refRe := regexp.MustCompile(`(?i)(monitorul oficial|legea nr|ril nr|decizia)`)
 
@@ -301,18 +301,22 @@ func parseCodeFile(path, codeID, codeTitle string) (*ParsedCode, error) {
 				currentChapter.Sections = append(currentChapter.Sections, sec)
 				currentSection = &currentChapter.Sections[len(currentChapter.Sections)-1]
 			}
-			articleOrder++
-			matches := articleRe.FindStringSubmatch(line)
-			num := ""
-			if len(matches) > 1 {
-				num = matches[1]
-			}
-			if currentSubsection != nil {
-				currentArticle = &Article{ID: fmt.Sprintf("book_%d_title_%d_ch_%d_sec_%d_sub_%d_art_%d", bookOrder, titleOrder, chapterOrder, sectionOrder, subsectionOrder, articleOrder), Number: num, Order: articleOrder}
-			} else {
-				currentArticle = &Article{ID: fmt.Sprintf("book_%d_title_%d_ch_%d_sec_%d_art_%d", bookOrder, titleOrder, chapterOrder, sectionOrder, articleOrder), Number: num, Order: articleOrder}
-			}
-			expectTitle = true
+                        articleOrder++
+                        matches := articleRe.FindStringSubmatch(line)
+                        num := ""
+                        title := ""
+                        if len(matches) > 1 {
+                                num = matches[1]
+                        }
+                        if len(matches) > 2 {
+                                title = matches[2]
+                        }
+                        if currentSubsection != nil {
+                                currentArticle = &Article{ID: fmt.Sprintf("book_%d_title_%d_ch_%d_sec_%d_sub_%d_art_%d", bookOrder, titleOrder, chapterOrder, sectionOrder, subsectionOrder, articleOrder), Number: num, Title: title, Order: articleOrder}
+                        } else {
+                                currentArticle = &Article{ID: fmt.Sprintf("book_%d_title_%d_ch_%d_sec_%d_art_%d", bookOrder, titleOrder, chapterOrder, sectionOrder, articleOrder), Number: num, Title: title, Order: articleOrder}
+                        }
+                        expectTitle = title == ""
 		case noteRe.MatchString(line):
 			collectingNote = true
 			noteLines = []string{line}

--- a/dashbord-react/src/CodeTextTabs.tsx
+++ b/dashbord-react/src/CodeTextTabs.tsx
@@ -479,7 +479,9 @@ export default function CodeTextTabs() {
           </div>
         ) : (
           <div className="flex items-center space-x-2">
-            <h3 className="font-semibold text-lg mt-2">
+            <h3
+              className={`font-semibold mt-2 ${level === 0 ? "text-xl" : "text-lg"}`}
+            >
               {section.type} {section.name}
             </h3>
             <Button
@@ -679,7 +681,9 @@ export default function CodeTextTabs() {
         ) : (
           <div className="p-2 border rounded bg-gray-50">
             <div className="flex items-center space-x-2">
-              <span className="text-sm">{note.type}</span>
+              <span className="text-sm">
+                {note.type === "Decision" ? "Decizie" : note.type}
+              </span>
               <Button
                 variant="outline"
                 size="sm"

--- a/dashbord-react/src/lib/parseCode.ts
+++ b/dashbord-react/src/lib/parseCode.ts
@@ -43,7 +43,7 @@ export function parseRawCode(text: string, id = "custom", title = "Cod personal"
   const chapterRe = /^Capitolul/i;
   const sectionRe = /^Sec[tț]iunea/i;
   const subsectionRe = /^Subsec[tț]iunea/i;
-  const articleRe = /^Articolul\s+(\d+)/i;
+  const articleRe = /^Articolul\s+(\d+)\s*(?:-\s*(.+))?/i;
   const noteRe = /^Not[aă]/i;
   const decisionRe = /^Decizie/i;
   const editRe = /^Edit\b/i;
@@ -261,6 +261,7 @@ export function parseRawCode(text: string, id = "custom", title = "Cod personal"
       articleOrder++;
       lastArticleNum = numVal;
       const num = artMatch[1] || "";
+      const inlineTitle = artMatch[2] || "";
       if (!currentSection && !currentSub) {
         // create default section
         sectionOrder++;
@@ -290,11 +291,11 @@ export function parseRawCode(text: string, id = "custom", title = "Cod personal"
           ? `book_${bookOrder}_title_${titleOrder}_ch_${chapterOrder}_sec_${sectionOrder}_sub_${subOrder}_art_${articleOrder}`
           : `book_${bookOrder}_title_${titleOrder}_ch_${chapterOrder}_sec_${sectionOrder}_art_${articleOrder}`,
         number: num,
-        title: "",
+        title: inlineTitle,
         content: "",
         notes: [],
       };
-      expectTitle = true;
+      expectTitle = inlineTitle === "";
       continue;
     }
 


### PR DESCRIPTION
## Summary
- handle article titles on same line in `parseCode.ts`
- show larger section titles at top level
- display `Decision` items as `Decizie`
- update Go parser for article titles on same line

## Testing
- `go vet ./...` *(fails: forbidden)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843ee6aaa348323ba5ef491e325fcbe