### PR TITLE
Fix duplicate article titles in Codurile la Zi

### DIFF
--- a/dashbord-react/src/CodeTextTabs.tsx
+++ b/dashbord-react/src/CodeTextTabs.tsx
@@ -271,6 +271,23 @@ export default function CodeTextTabs() {
       parent.content.push(currentNote);
     }
 
+    function cleanContent(items: (Section | Article | Note)[]) {
+      for (const item of items) {
+        if ("type" in item) {
+          if (item.type !== "Note" && item.type !== "Decision") {
+            cleanContent(item.content);
+          }
+        } else if (
+          item.title &&
+          item.content.length > 0 &&
+          item.content[0].trim() === item.title.trim()
+        ) {
+          item.content.shift();
+        }
+      }
+    }
+
+    cleanContent(structure);
     return structure;
   }
 


### PR DESCRIPTION
## Summary
- ensure parsed articles don't repeat their title as the first content line
- recursively remove duplicate title lines during parsing

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6843f2117c0083238ceadcd83c6516d2