### PR TITLE
Fix article save crash and update dashboard

### DIFF
--- a/dashbord-react/src/App.tsx
+++ b/dashbord-react/src/App.tsx
@@ -1,8 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import BookEditor, { Book as BookType } from './BookEditor';
 import NewsEditor, { NewsItem } from './NewsEditor';
-import CodeEditor from './CodeEditor';
-import RawCodeEditor from './RawCodeEditor';
 import CodeTextTabs from './CodeTextTabs';
 
 interface LoginProps {
@@ -66,9 +64,7 @@ function Login({ onLogin }: LoginProps) {
 
 const sections = [
   { key: 'materie', label: 'Materie', icon: 'menu_book' },
-  { key: 'codes', label: 'Codurile actualizate', icon: 'library_books' },
-  { key: 'codes2', label: 'Codurile 2', icon: 'description' },
-  { key: 'coduri_lazi', label: 'Codurile la zi', icon: 'article' },
+  { key: 'coduri_lazi', label: 'Codurile actualizate', icon: 'article' },
   { key: 'noutati', label: 'Noutati', icon: 'feed' },
   { key: 'grile', label: 'Grile', icon: 'view_list' },
   { key: 'meciuri', label: 'Grile meciuri', icon: 'sports_esports' },
@@ -338,12 +334,6 @@ function Dashboard({ onLogout }: DashboardProps) {
     }
     if (section === 'noutati') {
       return <NewsList items={news} onUpdate={updateNews} onEdit={setEditingNews} />;
-    }
-    if (section === 'codes') {
-      return <CodeEditor />;
-    }
-    if (section === 'codes2') {
-      return <RawCodeEditor />;
     }
     if (section === 'coduri_lazi') {
       return <CodeTextTabs />;

--- a/dashbord-react/src/CodeTextTabs.tsx
+++ b/dashbord-react/src/CodeTextTabs.tsx
@@ -84,8 +84,8 @@ export default function CodeTextTabs() {
     fetchData();
   };
 
-  const handleSaveAll = () => {
-    const data = texts[active];
+  const handleSaveAll = (override?: Section[]) => {
+    const data = override || texts[active];
     fetch(`/api/save-code-text/${active}`, {
       method: "POST",
       headers: {
@@ -307,7 +307,11 @@ export default function CodeTextTabs() {
       }
       return {
         ...section,
-        content: handleSaveSection(sectionId, section.content),
+        content: section.content.map((item) =>
+          "type" in item && item.type !== "Note" && item.type !== "Decision"
+            ? handleSaveSection(sectionId, [item as Section])[0]
+            : item,
+        ),
       };
     });
   }
@@ -335,17 +339,19 @@ export default function CodeTextTabs() {
         return {
           ...section,
           content: section.content.map((item) =>
-            "type" in item
-              ? item
-              : `${item.number}-${item.title}` === editingArticle && editArticle
-                ? { ...editArticle }
-                : item,
+            "number" in item && `${item.number}-${item.title}` === editingArticle && editArticle
+              ? { ...editArticle }
+              : item,
           ),
         };
       }
       return {
         ...section,
-        content: handleSaveArticle(sectionId, section.content),
+        content: section.content.map((item) =>
+          "type" in item && item.type !== "Note" && item.type !== "Decision"
+            ? handleSaveArticle(sectionId, [item as Section])[0]
+            : item,
+        ),
       };
     });
   }
@@ -482,10 +488,12 @@ export default function CodeTextTabs() {
             <Button
               variant="outline"
               onClick={() => {
-                setTexts((prev) => ({
-                  ...prev,
-                  [active]: handleSaveSection(sectionId, prev[active]),
-                }));
+                setTexts((prev) => {
+                  const updated = handleSaveSection(sectionId, prev[active]);
+                  const next = { ...prev, [active]: updated };
+                  handleSaveAll(updated);
+                  return next;
+                });
                 setEditingSection(null);
               }}
             >
@@ -596,10 +604,12 @@ export default function CodeTextTabs() {
             <Button
               variant="outline"
               onClick={() => {
-                setTexts((prev) => ({
-                  ...prev,
-                  [active]: handleSaveArticle(sectionId, prev[active]),
-                }));
+                setTexts((prev) => {
+                  const updated = handleSaveArticle(sectionId, prev[active]);
+                  const next = { ...prev, [active]: updated };
+                  handleSaveAll(updated);
+                  return next;
+                });
                 setEditingArticle(null);
                 setEditArticle(null);
               }}
@@ -684,10 +694,12 @@ export default function CodeTextTabs() {
             <Button
               variant="outline"
               onClick={() => {
-                setTexts((prev) => ({
-                  ...prev,
-                  [active]: handleSaveNote(noteId, prev[active]),
-                }));
+                setTexts((prev) => {
+                  const updated = handleSaveNote(noteId, prev[active]);
+                  const next = { ...prev, [active]: updated };
+                  handleSaveAll(updated);
+                  return next;
+                });
                 setEditingNote(null);
                 setEditNoteContent("");
               }}


### PR DESCRIPTION
## Summary
- fix recursion bug in `handleSaveArticle`
- avoid recursion errors in `handleSaveSection`
- automatically send updates to backend when saving edits
- remove unused dashboard sections and rename remaining one

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843f767002c83238870439ec19aa7f6