### PR TITLE
Fix closing parentheses in modern_code_reader

### DIFF
--- a/lib/pages/modern_code_reader.dart
+++ b/lib/pages/modern_code_reader.dart
@@ -290,9 +290,11 @@ class _ModernCodeReaderState extends State<ModernCodeReader>
                             _buildFavoriteView(),
                           ],
                         ),
+          ),
         ),
       ),
     );
+
   }
 
   List<Widget> _buildSectionWidgets(List<dynamic> items, int level) {


### PR DESCRIPTION
## Summary
- fix missing closing parenthesis in `ModernCodeReader`

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844080370708323acfb281e6655c54a