### PR TITLE
Make API URL configurable

### DIFF
--- a/lib/config.dart
+++ b/lib/config.dart
@@ -1,0 +1,11 @@
+const String apiBaseUrl = String.fromEnvironment(
+  'API_URL',
+  defaultValue: 'http://localhost:8080/api',
+);
+
+String get wsBaseUrl {
+  if (apiBaseUrl.startsWith('https')) {
+    return apiBaseUrl.replaceFirst('https', 'wss');
+  }
+  return apiBaseUrl.replaceFirst('http', 'ws');
+}

--- a/lib/pages/backend/providers/auth_provider.dart
+++ b/lib/pages/backend/providers/auth_provider.dart
@@ -266,7 +266,7 @@ class AuthProvider extends ChangeNotifier {
       final tempApiService = ApiServiceLogin(token: null);
       
       final response = await http.get(
-        Uri.parse('http://192.168.8.123:8080/api/profile'),
+        Uri.parse('${ApiService.baseUrl}/profile'),
         headers: {'Content-Type': 'application/json'},
       );
       

--- a/lib/pages/backend/providers/chat_provider.dart
+++ b/lib/pages/backend/providers/chat_provider.dart
@@ -8,6 +8,7 @@ import 'package:web_socket_channel/web_socket_channel.dart';
 import '../models/chat_models.dart';
 import '../models/user_model.dart';
 import '../services/api_service_chat.dart';
+import '../services/api_service.dart';
 import '../services/api_service_login.dart';
 import 'package:intl/intl.dart';
 import 'package:intl/date_symbol_data_local.dart';
@@ -62,7 +63,7 @@ class ChatProvider with ChangeNotifier {
     _reconnectTimer?.cancel();
     _channel?.sink.close();
 
-    final baseUrl = 'ws://192.168.8.123:8080/api/ws';
+    final baseUrl = '${ApiService.wsBaseUrl}/ws';
 
     try {
       print('Connecting to WebSocket: $baseUrl');

--- a/lib/pages/backend/services/api_service.dart
+++ b/lib/pages/backend/services/api_service.dart
@@ -4,12 +4,11 @@ import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:http/http.dart' as http;
+import '../../../config.dart' as config;
 
 class ApiService {
-  static const String baseUrl = String.fromEnvironment(
-    'API_URL',
-    defaultValue: 'http://192.168.8.123:8080/api',
-  );
+  static const String baseUrl = config.apiBaseUrl;
+  static String get wsBaseUrl => config.wsBaseUrl;
   final String? token;
   final Dio _dio = Dio();
   final _storage = const FlutterSecureStorage();

--- a/lib/pages/backend/services/api_service_chat.dart
+++ b/lib/pages/backend/services/api_service_chat.dart
@@ -359,9 +359,9 @@ class ApiServiceChat extends ApiService {
 
   void connectDashboardWebSocket() {
     try {
-      print('Connecting to Dashboard WebSocket at: ws://192.168.8.123:8080/api/dashboard/ws');
+      print('Connecting to Dashboard WebSocket at: ${ApiService.wsBaseUrl}/dashboard/ws');
       _dashboardWsChannel = WebSocketChannel.connect(
-        Uri.parse('ws://192.168.8.123:8080/api/dashboard/ws'),
+        Uri.parse('${ApiService.wsBaseUrl}/dashboard/ws'),
       );
 
       _dashboardWsStream = _dashboardWsChannel!.stream.asBroadcastStream();

--- a/lib/pages/modern_code_reader.dart
+++ b/lib/pages/modern_code_reader.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 import '../models/code_text.dart';
+import 'backend/services/api_service.dart';
 
 class ModernCodeReader extends StatefulWidget {
   final String codeId;
@@ -28,7 +29,7 @@ class _ModernCodeReaderState extends State<ModernCodeReader> {
   }
 
   Future<void> _load() async {
-    final baseUrl = const String.fromEnvironment('API_URL', defaultValue: 'http://localhost:8080');
+    final baseUrl = ApiService.baseUrl.replaceFirst('/api', '');
     if (mounted) {
       setState(() {
         _loading = true;

--- a/lib/services/book_service.dart
+++ b/lib/services/book_service.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'package:http/http.dart' as http;
+import '../pages/backend/services/api_service.dart';
 
 class AdminBook {
   final String id;
@@ -21,7 +22,7 @@ class AdminBook {
 
 class BookService {
   static Future<List<AdminBook>> fetchBooks() async {
-    final uri = Uri.parse('http://localhost:8080/api/books');
+    final uri = Uri.parse('${ApiService.baseUrl}/books');
     final res = await http.get(uri);
     if (res.statusCode == 200) {
       final List<dynamic> data = jsonDecode(res.body);

--- a/lib/services/code_parser.dart
+++ b/lib/services/code_parser.dart
@@ -2,10 +2,10 @@ import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
 import 'dart:convert';
 import '../models/code_structure.dart';
+import '../pages/backend/services/api_service.dart';
 
 class CodeParser {
-  static const String _baseUrl = String.fromEnvironment('API_URL', 
-      defaultValue: 'http://localhost:8080');
+  static final String _baseUrl = ApiService.baseUrl.replaceFirst('/api', '');
   
   static final Map<String, String> _codeTitles = {
     'civil': 'Codul Civil',

--- a/lib/services/news_service.dart
+++ b/lib/services/news_service.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'package:http/http.dart' as http;
+import '../pages/backend/services/api_service.dart';
 
 class NewsItem {
   final String id;
@@ -32,7 +33,7 @@ class NewsItem {
 
 class NewsService {
   static Future<List<NewsItem>> fetchNews() async {
-    final uri = Uri.parse('http://localhost:8080/api/news');
+    final uri = Uri.parse('${ApiService.baseUrl}/news');
     final res = await http.get(uri);
     if (res.statusCode == 200) {
       final List<dynamic> data = jsonDecode(res.body);


### PR DESCRIPTION
## Summary
- add `lib/config.dart` for API base URL
- use `ApiService.baseUrl` and `wsBaseUrl` throughout
- replace hardcoded localhost/IP addresses with config

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684498f889d08323a2e1027bfddb8eb2