### PR TITLE
Fix API URL config and improve documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,25 @@ A few resources to get you started if this is your first Flutter project:
 For help getting started with Flutter development, view the
 [online documentation](https://docs.flutter.dev/), which offers tutorials,
 samples, guidance on mobile development, and a full API reference.
+
+## Backend API
+
+The Flutter app communicates with the Go backend found in the `backend/` directory. Start it locally with:
+
+```bash
+cd backend
+go run .
+```
+
+By default the server listens on `localhost:8080`.
+
+### Setting the API URL
+
+The Flutter app reads the backend URL from the `API_URL` dart define. If not provided it defaults to an emulator friendly address. When running on an Android emulator pass:
+
+```bash
+flutter run --dart-define=API_URL=http://10.0.2.2:8080/api
+```
+
+Replace `10.0.2.2` with the IP of your backend when running on a device.
+

--- a/lib/config.dart
+++ b/lib/config.dart
@@ -1,7 +1,23 @@
-const String apiBaseUrl = String.fromEnvironment(
-  'API_URL',
-  defaultValue: 'http://localhost:8080/api',
-);
+import 'package:flutter/foundation.dart';
+
+const String _envApiUrl = String.fromEnvironment('API_URL');
+
+String get apiBaseUrl {
+  if (_envApiUrl.isNotEmpty) {
+    return _envApiUrl;
+  }
+
+  if (kIsWeb) {
+    return 'http://localhost:8080/api';
+  }
+
+  if (defaultTargetPlatform == TargetPlatform.android) {
+    // Android emulators cannot access the host machine via localhost
+    return 'http://10.0.2.2:8080/api';
+  }
+
+  return 'http://localhost:8080/api';
+}
 
 String get wsBaseUrl {
   if (apiBaseUrl.startsWith('https')) {

--- a/lib/pages/backend/services/api_service.dart
+++ b/lib/pages/backend/services/api_service.dart
@@ -7,7 +7,7 @@ import 'package:http/http.dart' as http;
 import '../../../config.dart' as config;
 
 class ApiService {
-  static const String baseUrl = config.apiBaseUrl;
+  static final String baseUrl = config.apiBaseUrl;
   static String get wsBaseUrl => config.wsBaseUrl;
   final String? token;
   final Dio _dio = Dio();


### PR DESCRIPTION
## Summary
- update `config.dart` to compute API base URL per platform
- adjust `ApiService` to use runtime URL
- document backend launch and API_URL usage in the README

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68451e999ef483239fcb0be8e9688d6b