### PR TITLE
Allow API access from devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@ cd backend
 go run .
 ```
 
-By default the server listens on `localhost:8080`.
+By default the server listens on `0.0.0.0:8080` so it can be reached from the
+host machine via `http://localhost:8080` or from other devices on your local
+network using your machine's IP address (for example `http://192.168.8.123:8080`).
 
 ### Setting the API URL
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -23,4 +23,5 @@ go run .
 This compiles all Go files in the directory, including `parser.go` which
 defines helper functions used by `main.go`.
 
-The server listens on `localhost:8080`.
+The server listens on `0.0.0.0:8080`, allowing access from `http://localhost:8080`
+or using your computer's local IP address such as `http://192.168.8.123:8080`.

--- a/backend/main.go
+++ b/backend/main.go
@@ -1280,5 +1280,7 @@ func main() {
 
 	r.Static("/uploads", "./uploads")
 
-	r.Run(":8080")
+	// Listen on all network interfaces so the API is reachable from other
+	// devices on the local network (e.g. using the machine's IP address)
+	r.Run("0.0.0.0:8080")
 }


### PR DESCRIPTION
## Summary
- expose backend on all network interfaces so a device can reach it via IP
- document how to access the API from localhost or a LAN IP

## Testing
- `go vet ./...` *(fails: forbidden downloading modules)*
- `go build .` *(fails: forbidden downloading modules)*

------
https://chatgpt.com/codex/tasks/task_e_68452ad91b10832393ec88ff83e51231