### PR TITLE
Allow network access and dynamic base URL

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -1399,5 +1399,5 @@ func main() {
 
 	// Listen on localhost. If you need to access the API from other
 	// devices on your network, bind to your machine's IP or "0.0.0.0".
-	r.Run(":8080")
+        r.Run("0.0.0.0:8080")
 }

--- a/lib/config.dart
+++ b/lib/config.dart
@@ -16,7 +16,7 @@ String get apiBaseUrl {
     return 'http://10.0.2.2:8080/api';
   }
 
-  return 'http://localhost:8080/api';
+  return 'http://192.168.8.123:8080/api';
 }
 
 String get wsBaseUrl {

--- a/lib/pages/backend/auth/login_page.dart
+++ b/lib/pages/backend/auth/login_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:provider/provider.dart';
+import 'package:flutter/foundation.dart';
 import '../providers/auth_provider.dart';
 import 'register_page.dart';
 import '../../../main_container.dart';
@@ -53,10 +54,19 @@ class _LoginPageState extends State<LoginPage> {
 
     try {
       print('Attempting login from LoginPage'); // Debug print
+      String baseUrl;
+      if (kIsWeb) {
+        baseUrl = 'http://localhost:8080';
+      } else if (defaultTargetPlatform == TargetPlatform.android) {
+        baseUrl = 'http://10.0.2.2:8080';
+      } else {
+        baseUrl = 'http://192.168.8.123:8080';
+      }
       final authProvider = context.read<AuthProvider>();
       await authProvider.login(
         identifier: _identifierController.text,
         password: _passwordController.text,
+        baseUrl: baseUrl,
       );
       print('Login successful, checking authentication status'); // Debug print
       print('isAuthenticated: ${authProvider.isAuthenticated}'); // Debug print

--- a/lib/pages/backend/auth/register_page.dart
+++ b/lib/pages/backend/auth/register_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:provider/provider.dart';
+import 'package:flutter/foundation.dart';
 import '../providers/auth_provider.dart';
 import '../../../main_container.dart';
 
@@ -50,11 +51,20 @@ class _RegisterPageState extends State<RegisterPage> {
     setState(() => _isLoading = true);
 
     try {
+      String baseUrl;
+      if (kIsWeb) {
+        baseUrl = 'http://localhost:8080';
+      } else if (defaultTargetPlatform == TargetPlatform.android) {
+        baseUrl = 'http://10.0.2.2:8080';
+      } else {
+        baseUrl = 'http://192.168.8.123:8080';
+      }
       // Înregistrare utilizator
       await context.read<AuthProvider>().register(
         username: _usernameController.text,
         email: _emailController.text,
         password: _passwordController.text,
+        baseUrl: baseUrl,
       );
 
       // Autentificare automată după înregistrare
@@ -62,6 +72,7 @@ class _RegisterPageState extends State<RegisterPage> {
         await context.read<AuthProvider>().login(
           identifier: _emailController.text,
           password: _passwordController.text,
+          baseUrl: baseUrl,
         );
 
         // Dacă autentificarea a reușit, navigăm direct în aplicație

--- a/lib/pages/backend/providers/auth_provider.dart
+++ b/lib/pages/backend/providers/auth_provider.dart
@@ -53,7 +53,11 @@ class AuthProvider extends ChangeNotifier {
   User? get currentUser => _currentUser;
   ApiServiceLogin get apiService => _apiService;
 
-  Future<void> login({required String identifier, required String password}) async {
+  Future<void> login({
+    required String identifier,
+    required String password,
+    String? baseUrl,
+  }) async {
     try {
       print('Starting login process');
 
@@ -61,6 +65,7 @@ class AuthProvider extends ChangeNotifier {
       final response = await tempApiService.login(
         identifier: identifier,
         password: password,
+        baseUrl: baseUrl,
       );
 
       _token = response['token'];
@@ -86,6 +91,7 @@ class AuthProvider extends ChangeNotifier {
     required String username,
     required String email,
     required String password,
+    String? baseUrl,
   }) async {
     try {
       print('Starting registration process');
@@ -95,6 +101,7 @@ class AuthProvider extends ChangeNotifier {
         username: username,
         email: email,
         password: password,
+        baseUrl: baseUrl,
       );
       print('Registration successful');
     } catch (e) {

--- a/lib/pages/backend/services/api_service_login.dart
+++ b/lib/pages/backend/services/api_service_login.dart
@@ -21,11 +21,12 @@ class ApiServiceLogin extends ApiService {
   Future<Map<String, dynamic>> login({
     required String identifier,
     required String password,
+    String? baseUrl,
   }) async {
     print('Attempting login for identifier: $identifier');
     try {
       final response = await http.post(
-        Uri.parse('${ApiService.baseUrl}/auth/login'),
+        Uri.parse('${baseUrl ?? ApiService.baseUrl}/auth/login'),
         headers: headers,
         body: jsonEncode({
           identifier.contains('@') ? 'email' : 'username': identifier,
@@ -52,11 +53,12 @@ class ApiServiceLogin extends ApiService {
     required String username,
     required String email,
     required String password,
+    String? baseUrl,
   }) async {
     print('Attempting registration for email: $email');
     try {
       final response = await http.post(
-        Uri.parse('${ApiService.baseUrl}/auth/register'),
+        Uri.parse('${baseUrl ?? ApiService.baseUrl}/auth/register'),
         headers: headers,
         body: jsonEncode({
           'username': username,


### PR DESCRIPTION
## Summary
- allow backend to accept connections from local network
- add device-aware base URL logic for login/register pages
- pass chosen base URL to AuthProvider and ApiService
- update default base URL for physical devices

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845e8adbaec8323988dcc96af04da8b