### PR TITLE
Add placeholder Grile dashboard page

### DIFF
--- a/dashbord-react/src/App.tsx
+++ b/dashbord-react/src/App.tsx
@@ -4,6 +4,7 @@ import NewsEditor, { NewsItem } from './NewsEditor';
 import CodeEditor from './CodeEditor';
 import CodurileLaZi from './CodurileLaZi';
 import CodeTextTabs from './CodeTextTabs';
+import Grile from './Grile';
 
 interface LoginProps {
   onLogin: () => void;
@@ -347,6 +348,9 @@ function Dashboard({ onLogout }: DashboardProps) {
     }
     if (section === 'codurile_2_0') {
       return <CodeTextTabs />;
+    }
+    if (section === 'grile') {
+      return <Grile />;
     }
     const s = sections.find((x) => x.key === section);
     return (

--- a/dashbord-react/src/Grile.tsx
+++ b/dashbord-react/src/Grile.tsx
@@ -1,0 +1,53 @@
+import React, { useState } from 'react';
+import { Button } from '@/components/ui/button';
+
+interface Tab {
+  id: string;
+  label: string;
+}
+
+const tabs: Tab[] = [
+  { id: 'teme', label: 'Teme' },
+  { id: 'suplimentare', label: 'Teste suplimentare' },
+  { id: 'combinate', label: 'Teste combinate' },
+  { id: 'simulari', label: 'Simulări' },
+  { id: 'ani', label: 'Grile date în anii anteriori' },
+];
+
+export default function Grile() {
+  const [active, setActive] = useState<string>(tabs[0].id);
+
+  const renderTab = () => {
+    switch (active) {
+      case 'teme':
+        return <div></div>;
+      case 'suplimentare':
+        return <div></div>;
+      case 'combinate':
+        return <div></div>;
+      case 'simulari':
+        return <div></div>;
+      case 'ani':
+        return <div></div>;
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="border-b mb-4 space-x-2">
+        {tabs.map((t) => (
+          <Button
+            key={t.id}
+            variant={active === t.id ? 'default' : 'secondary'}
+            onClick={() => setActive(t.id)}
+          >
+            {t.label}
+          </Button>
+        ))}
+      </div>
+      {renderTab()}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create `Grile` page with empty tabs
- register `Grile` page in the dashboard

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6845f0f1e5708323ba5d1064d74a3136