### PR TITLE
Fix login/register base URL

### DIFF
--- a/lib/pages/backend/auth/login_page.dart
+++ b/lib/pages/backend/auth/login_page.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:provider/provider.dart';
-import 'package:flutter/foundation.dart';
 import '../providers/auth_provider.dart';
 import 'register_page.dart';
+import '../services/api_service.dart';
 import '../../../main_container.dart';
 
 class LoginPage extends StatefulWidget {
@@ -54,14 +54,7 @@ class _LoginPageState extends State<LoginPage> {
 
     try {
       print('Attempting login from LoginPage'); // Debug print
-      String baseUrl;
-      if (kIsWeb) {
-        baseUrl = 'http://localhost:8080';
-      } else if (defaultTargetPlatform == TargetPlatform.android) {
-        baseUrl = 'http://10.0.2.2:8080';
-      } else {
-        baseUrl = 'http://192.168.8.123:8080';
-      }
+      final String baseUrl = ApiService.baseUrl;
       final authProvider = context.read<AuthProvider>();
       await authProvider.login(
         identifier: _identifierController.text,

--- a/lib/pages/backend/auth/register_page.dart
+++ b/lib/pages/backend/auth/register_page.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:provider/provider.dart';
-import 'package:flutter/foundation.dart';
 import '../providers/auth_provider.dart';
+import '../services/api_service.dart';
 import '../../../main_container.dart';
 
 class RegisterPage extends StatefulWidget {
@@ -51,14 +51,7 @@ class _RegisterPageState extends State<RegisterPage> {
     setState(() => _isLoading = true);
 
     try {
-      String baseUrl;
-      if (kIsWeb) {
-        baseUrl = 'http://localhost:8080';
-      } else if (defaultTargetPlatform == TargetPlatform.android) {
-        baseUrl = 'http://10.0.2.2:8080';
-      } else {
-        baseUrl = 'http://192.168.8.123:8080';
-      }
+      final String baseUrl = ApiService.baseUrl;
       // Înregistrare utilizator
       await context.read<AuthProvider>().register(
         username: _usernameController.text,


### PR DESCRIPTION
## Summary
- adjust login/register pages to use `ApiService.baseUrl`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845fccf4e148323b5e745417f5cd2d3