### PR TITLE
Fix image asset paths in book service

### DIFF
--- a/lib/services/book_service.dart
+++ b/lib/services/book_service.dart
@@ -11,10 +11,14 @@ class AdminBook {
   AdminBook({required this.id, required this.title, required this.image, required this.content});
 
   factory AdminBook.fromJson(Map<String, dynamic> json) {
+    String image = (json['image'] as String?)?.replaceFirst('../', '') ?? '';
+    if (!image.startsWith('http') && !image.startsWith('assets/')) {
+      image = 'assets/' + image;
+    }
     return AdminBook(
       id: json['id'] ?? '',
       title: json['title'] ?? '',
-      image: (json['image'] as String?)?.replaceFirst('../', '') ?? '',
+      image: image,
       content: json['content'] ?? '',
     );
   }


### PR DESCRIPTION
## Summary
- fix admin book asset path to include `assets/` prefix when necessary

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68467eae33788323b81748ad7c663030