### PR TITLE
Integrate DigitalOcean agent for grila explanations

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+VITE_AGENT_ENDPOINT=https://ti4oro4gz7lxwrbg7gb2w3sa.agents.do-ai.run
+VITE_AGENT_ACCESS_KEY=tVWw3yhQsb-khtJX9K7v_HnJhcBNG8jr

--- a/dashbord-react/src/Grile.tsx
+++ b/dashbord-react/src/Grile.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import { explainQuestion } from "@/lib/agent";
 
 interface Tab {
   id: string;
@@ -146,12 +147,18 @@ export default function Grile() {
     });
   };
 
-  const generateExplanation = (qi: number) => {
-    setQuestions((prev) => {
-      const copy = [...prev];
-      copy[qi].explanation = `Explicație generată pentru întrebarea ${qi + 1}.`;
-      return copy;
-    });
+  const generateExplanation = async (qi: number) => {
+    try {
+      const exp = await explainQuestion(questions[qi]);
+      setQuestions((prev) => {
+        const copy = [...prev];
+        copy[qi].explanation = exp;
+        return copy;
+      });
+    } catch (err) {
+      console.error(err);
+      alert("Eroare la generarea explicației");
+    }
   };
 
   const publishTest = () => {

--- a/dashbord-react/src/lib/agent.ts
+++ b/dashbord-react/src/lib/agent.ts
@@ -1,0 +1,42 @@
+export interface GrilaQuestion {
+  text: string;
+  answers: string[];
+  correct: number[];
+}
+
+/**
+ * Trimite întrebarea la Agent-Juridic și întoarce explicația.
+ * !!! Atenție: cheia este expusă în bundle. Ține repo-ul privat sau adaugă un proxy server dacă vrei mai multă securitate.
+ */
+export async function explainQuestion(q: GrilaQuestion): Promise<string> {
+  const prompt = `
+Citește cu atenție grila de mai jos, apoi explică de ce variantele greșite sunt greșite și de ce varianta/variantele corecte sunt corecte. Folosește DOAR informații din Codul civil și Codul penal din baza KB și citează articolul/alin. exact. Evită informații externe. Răspunde în 3-5 fraze clare, compară explicit fiecare variantă.
+
+Întrebare:
+${q.text}
+
+Variante:
+${q.answers.map((a,i)=>`${String.fromCharCode(65+i)}. ${a}`).join("\n")}
+
+Răspuns corect: ${q.correct.map(i=>String.fromCharCode(65+i)).join(", ")}
+`.trim();
+
+  const res = await fetch(
+    `${import.meta.env.VITE_AGENT_ENDPOINT}/api/v1/chat/completions`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${import.meta.env.VITE_AGENT_ACCESS_KEY}`,
+      },
+      body: JSON.stringify({
+        messages: [{ role: "user", content: prompt }],
+        stream: false
+      })
+    }
+  );
+
+  if (!res.ok) throw new Error(`Agent error ${res.status}`);
+  const data = await res.json();
+  return data.choices?.[0]?.message?.content?.trim() ?? "";
+}


### PR DESCRIPTION
## Summary
- configure new DigitalOcean agent endpoint and key
- add agent client in React lib
- call agent for explanations from `Grile` component

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6846aab8f9c88323be43fb3844af3e80