### PR TITLE
Add loader for AI explanation

### DIFF
--- a/dashbord-react/src/Grile.tsx
+++ b/dashbord-react/src/Grile.tsx
@@ -55,6 +55,7 @@ export default function Grile() {
   const [savedTests, setSavedTests] = useState<Test[]>([]);
   const [selectedTestId, setSelectedTestId] = useState<string | null>(null);
   const [editingTest, setEditingTest] = useState<Test | null>(null);
+  const [loadingExp, setLoadingExp] = useState<Record<number, boolean>>({});
 
   const stripAnswerPrefix = (t: string) => {
     const m = t.trim().match(/^[A-Za-z][.)]\s*(.+)$/);
@@ -148,6 +149,7 @@ export default function Grile() {
   };
 
   const generateExplanation = async (qi: number) => {
+    setLoadingExp((s) => ({ ...s, [qi]: true }));
     try {
       const exp = await explainQuestion(questions[qi]);
       setQuestions((prev) => {
@@ -158,6 +160,8 @@ export default function Grile() {
     } catch (err) {
       console.error(err);
       alert("Eroare la generarea explicației");
+    } finally {
+      setLoadingExp((s) => ({ ...s, [qi]: false }));
     }
   };
 
@@ -490,22 +494,31 @@ export default function Grile() {
                         variant="outline"
                         onClick={() => generateExplanation(qi)}
                         className="flex items-center space-x-1"
+                        disabled={loadingExp[qi]}
                       >
-                        <svg
-                          xmlns="http://www.w3.org/2000/svg"
-                          className="h-4 w-4"
-                          fill="none"
-                          viewBox="0 0 24 24"
-                          stroke="currentColor"
-                        >
-                          <path
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            strokeWidth={2}
-                            d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"
-                          />
-                        </svg>
-                        <span>Explicație AI</span>
+                        {loadingExp[qi] ? (
+                          <span>Se generează...</span>
+                        ) : q.explanation ? (
+                          <span>Explicație generată</span>
+                        ) : (
+                          <>
+                            <svg
+                              xmlns="http://www.w3.org/2000/svg"
+                              className="h-4 w-4"
+                              fill="none"
+                              viewBox="0 0 24 24"
+                              stroke="currentColor"
+                            >
+                              <path
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                                strokeWidth={2}
+                                d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"
+                              />
+                            </svg>
+                            <span>Explicație AI</span>
+                          </>
+                        )}
                       </Button>
                     </div>
                     {q.answers.map((a, ai) => (


### PR DESCRIPTION
## Summary
- show spinner-like text while AI explanations load in dashboard
- indicate when explanation is generated

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6846af5cfcf083239e3a846f06f9240a