### PR TITLE
Fix publish button disable issue

### DIFF
--- a/dashbord-react/src/components/ui/button.tsx
+++ b/dashbord-react/src/components/ui/button.tsx
@@ -34,11 +34,12 @@ export interface ButtonProps
     VariantProps<typeof buttonVariants> {}
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant, size, ...props }, ref) => {
+  ({ className, variant, size, type = "button", ...props }, ref) => {
     return (
       <button
         className={cn(buttonVariants({ variant, size, className }))}
         ref={ref}
+        type={type}
         {...props}
       />
     )


### PR DESCRIPTION
## Summary
- set default HTML `button` type to avoid unintended form submission

## Testing
- `npm run build`
- `dart test` *(fails: `dart: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6848701bd5ec8323b773df91ebb8d5a5