### PR TITLE
Preserve explanation paragraphs

### DIFF
--- a/dashbord-react/src/Grile.tsx
+++ b/dashbord-react/src/Grile.tsx
@@ -737,7 +737,17 @@ export default function Grile() {
                       <p className="text-sm text-gray-600">Nota: {q.note}</p>
                     )}
                     {q.explanation && (
-                      <p className="text-sm">Explicație: {q.explanation}</p>
+                      <div className="text-sm space-y-1">
+                        <p className="font-medium">Explicație:</p>
+                        {q.explanation
+                          .split(/\n+/)
+                          .filter((p) => p.trim())
+                          .map((p, i) => (
+                            <p key={i} className="indent-4">
+                              {p}
+                            </p>
+                          ))}
+                      </div>
                     )}
                   </div>
                 ))}
@@ -835,7 +845,17 @@ export default function Grile() {
                           <p className="text-sm text-gray-600">Nota: {q.note}</p>
                         )}
                         {q.explanation && (
-                          <p className="text-sm">Explicație: {q.explanation}</p>
+                          <div className="text-sm space-y-1">
+                            <p className="font-medium">Explicație:</p>
+                            {q.explanation
+                              .split(/\n+/)
+                              .filter((p) => p.trim())
+                              .map((p, i) => (
+                                <p key={i} className="indent-4">
+                                  {p}
+                                </p>
+                              ))}
+                          </div>
                         )}
                       </div>
                     ))}


### PR DESCRIPTION
## Summary
- format explanations from `Explicație AI` preserving paragraphs
- render each paragraph with a small indent so blank lines remain visible

## Testing
- `npm run build` *(fails: vite not found)*
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848776e819c832385461f171038f3f3