### PR TITLE
Dashboard updates and persistent storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ pubspec.lock
 dashbord-react/node_modules/
 dashbord-react/dist/
 dashbord-react/package-lock.json
+data/*
+!data/.gitkeep

--- a/backend/main.go
+++ b/backend/main.go
@@ -57,6 +57,16 @@ func detectRepoRoot() string {
 }
 
 var rootDir = detectRepoRoot()
+var dataDir = func() string {
+	if d := os.Getenv("DATA_DIR"); d != "" {
+		return d
+	}
+	return filepath.Join(rootDir, "data")
+}()
+
+func ensureDataDir() {
+	os.MkdirAll(dataDir, 0755)
+}
 
 type User struct {
 	ID        string   `json:"id"`
@@ -73,7 +83,7 @@ type User struct {
 var users = make(map[string]User)
 var tokens = make(map[string]string) // token -> username
 
-var tokensFile = filepath.Join(rootDir, "backend", "tokens.json")
+var tokensFile = filepath.Join(dataDir, "tokens.json")
 
 func loadTokens() {
 	data, err := os.ReadFile(tokensFile)
@@ -88,6 +98,7 @@ func saveTokens() {
 	if err != nil {
 		return
 	}
+	os.MkdirAll(dataDir, 0755)
 	_ = os.WriteFile(tokensFile, data, 0644)
 }
 
@@ -101,7 +112,7 @@ type ArticlePrefs struct {
 }
 
 var userArticlePrefs = make(map[string]*ArticlePrefs)
-var userArticlePrefsFile = filepath.Join(rootDir, "backend", "user_articles.json")
+var userArticlePrefsFile = filepath.Join(dataDir, "user_articles.json")
 
 func loadArticlePrefs() {
 	data, err := os.ReadFile(userArticlePrefsFile)
@@ -116,10 +127,11 @@ func saveArticlePrefs() {
 	if err != nil {
 		return
 	}
+	os.MkdirAll(dataDir, 0755)
 	_ = os.WriteFile(userArticlePrefsFile, data, 0644)
 }
 
-var userFile = filepath.Join(rootDir, "backend", "users.json")
+var userFile = filepath.Join(dataDir, "users.json")
 
 func loadUsers() {
 	data, err := os.ReadFile(userFile)
@@ -134,6 +146,7 @@ func saveUsers() {
 	if err != nil {
 		return
 	}
+	os.MkdirAll(dataDir, 0755)
 	_ = os.WriteFile(userFile, data, 0644)
 }
 
@@ -515,7 +528,11 @@ func saveBooks(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
-	if err := os.WriteFile(filepath.Join(rootDir, "dashbord-react", "books.json"), data, 0644); err != nil {
+	if err := os.MkdirAll(dataDir, 0755); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	if err := os.WriteFile(filepath.Join(dataDir, "books.json"), data, 0644); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
@@ -523,7 +540,7 @@ func saveBooks(c *gin.Context) {
 }
 
 func listBooks(c *gin.Context) {
-	data, err := ioutil.ReadFile(filepath.Join(rootDir, "dashbord-react", "books.json"))
+	data, err := ioutil.ReadFile(filepath.Join(dataDir, "books.json"))
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -547,7 +564,11 @@ func saveNews(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
-	if err := os.WriteFile(filepath.Join(rootDir, "dashbord-react", "news.json"), data, 0644); err != nil {
+	if err := os.MkdirAll(dataDir, 0755); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	if err := os.WriteFile(filepath.Join(dataDir, "news.json"), data, 0644); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
@@ -555,7 +576,7 @@ func saveNews(c *gin.Context) {
 }
 
 func listNews(c *gin.Context) {
-	data, err := ioutil.ReadFile(filepath.Join(rootDir, "dashbord-react", "news.json"))
+	data, err := ioutil.ReadFile(filepath.Join(dataDir, "news.json"))
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -579,7 +600,11 @@ func saveTests(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
-	if err := os.WriteFile(filepath.Join(rootDir, "backend", "tests.json"), data, 0644); err != nil {
+	if err := os.MkdirAll(dataDir, 0755); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	if err := os.WriteFile(filepath.Join(dataDir, "tests.json"), data, 0644); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
@@ -587,7 +612,7 @@ func saveTests(c *gin.Context) {
 }
 
 func listTests(c *gin.Context) {
-	path := filepath.Join(rootDir, "backend", "tests.json")
+	path := filepath.Join(dataDir, "tests.json")
 	data, err := ioutil.ReadFile(path)
 	if os.IsNotExist(err) {
 		data = []byte("[]")
@@ -1350,6 +1375,7 @@ func getFollowingHandler(c *gin.Context) {
 
 func main() {
 	fmt.Println("Using repository root:", rootDir)
+	ensureDataDir()
 	loadUsers()
 	loadTokens()
 	loadCodes()

--- a/dashbord-react/src/App.tsx
+++ b/dashbord-react/src/App.tsx
@@ -6,6 +6,10 @@ import CodurileLaZi from './CodurileLaZi';
 import CodeTextTabs from './CodeTextTabs';
 import Grile from './Grile';
 import GrileSpreadsheet from './GrileSpreadsheet';
+import TesteSuplimentare from './TesteSuplimentare';
+import TesteCombinate from './TesteCombinate';
+import Simulari from './Simulari';
+import BancaDeGrile from './BancaDeGrile';
 
 interface LoginProps {
   onLogin: () => void;
@@ -73,6 +77,10 @@ const sections = [
   { key: 'codurile_2_0', label: 'Codurile 2.0', icon: 'library_books' },
   { key: 'noutati', label: 'Noutati', icon: 'feed' },
   { key: 'grile', label: 'Grile', icon: 'view_list' },
+  { key: 'suplimentare', label: 'Teste suplimentare', icon: 'note_add' },
+  { key: 'combinate', label: 'Teste combinate', icon: 'playlist_add' },
+  { key: 'simulari', label: 'Simulari', icon: 'quiz' },
+  { key: 'banca', label: 'Banca de grile', icon: 'library_books' },
   { key: 'grile_2_0', label: 'Grile 2.0', icon: 'grid_on' },
   { key: 'meciuri', label: 'Grile meciuri', icon: 'sports_esports' },
 ];
@@ -353,6 +361,18 @@ function Dashboard({ onLogout }: DashboardProps) {
     }
     if (section === 'grile_2_0') {
       return <GrileSpreadsheet />;
+    }
+    if (section === 'suplimentare') {
+      return <TesteSuplimentare />;
+    }
+    if (section === 'combinate') {
+      return <TesteCombinate />;
+    }
+    if (section === 'simulari') {
+      return <Simulari />;
+    }
+    if (section === 'banca') {
+      return <BancaDeGrile />;
     }
     if (section === 'grile') {
       return <Grile />;

--- a/dashbord-react/src/BancaDeGrile.tsx
+++ b/dashbord-react/src/BancaDeGrile.tsx
@@ -1,0 +1,82 @@
+import React, { useEffect, useState } from 'react';
+import { Button } from '@/components/ui/button';
+
+interface Question {
+  text: string;
+  answers: string[];
+  correct: number[];
+  note: string;
+  explanation?: string;
+}
+
+interface Test {
+  id: string;
+  name: string;
+  subject: string;
+  questions: Question[];
+}
+
+const subjects = [
+  { id: 'civil', label: 'Drept civil' },
+  { id: 'dpc', label: 'Drept procesual civil' },
+  { id: 'penal', label: 'Drept penal' },
+  { id: 'dpp', label: 'Drept procesual penal' },
+];
+
+export default function BancaDeGrile() {
+  const [tests, setTests] = useState<Test[]>([]);
+  const [active, setActive] = useState(subjects[0].id);
+  const [query, setQuery] = useState('');
+
+  useEffect(() => {
+    const token = localStorage.getItem('token') || '';
+    fetch('/api/tests', { headers: { Authorization: `Bearer ${token}` } })
+      .then((r) => (r.ok ? r.json() : []))
+      .then(setTests)
+      .catch(() => {});
+  }, []);
+
+  const filtered = tests.filter(
+    (t) =>
+      t.subject === subjects.find((s) => s.id === active)?.label &&
+      (t.name.toLowerCase().includes(query.toLowerCase()) ||
+        t.questions.some((q) => q.text.toLowerCase().includes(query.toLowerCase())))
+  );
+
+  const grouped: Record<string, Test[]> = {};
+  for (const t of filtered) {
+    grouped[t.name] = grouped[t.name] ? [...grouped[t.name], t] : [t];
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="border-b space-x-2 mb-4">
+        {subjects.map((s) => (
+          <Button
+            key={s.id}
+            variant={active === s.id ? 'default' : 'secondary'}
+            onClick={() => setActive(s.id)}
+          >
+            {s.label}
+          </Button>
+        ))}
+      </div>
+      <input
+        className="border p-2 rounded w-full"
+        placeholder="Caută grile..."
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+      />
+      {Object.entries(grouped).map(([name, gtests]) => (
+        <div key={name} className="mt-4">
+          <h4 className="font-semibold">{name}</h4>
+          <ul className="pl-4 list-disc">
+            {gtests.map((t) => (
+              <li key={t.id}>{t.questions.length} grile</li>
+            ))}
+          </ul>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/dashbord-react/src/Grile.tsx
+++ b/dashbord-react/src/Grile.tsx
@@ -19,10 +19,6 @@ const tabs: Tab[] = [
   { id: "generator", label: "Generator" },
   { id: "creare", label: "Creare grile" },
   { id: "teme", label: "Teme" },
-  { id: "suplimentare", label: "Teste suplimentare" },
-  { id: "combinate", label: "Teste combinate" },
-  { id: "simulari", label: "Simulări" },
-  { id: "ani", label: "Grile date în anii anteriori" },
 ];
 
 const subjects = [
@@ -1111,14 +1107,6 @@ export default function Grile() {
             </div>
           </div>
         );
-      case "suplimentare":
-        return <div></div>;
-      case "combinate":
-        return <div></div>;
-      case "simulari":
-        return <div></div>;
-      case "ani":
-        return <div></div>;
       case "generator":
         return (
           <div className="flex space-x-4">

--- a/dashbord-react/src/Simulari.tsx
+++ b/dashbord-react/src/Simulari.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function Simulari() {
+  return <div className="p-4">Pagina Simulări - în curând</div>;
+}

--- a/dashbord-react/src/TesteCombinate.tsx
+++ b/dashbord-react/src/TesteCombinate.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function TesteCombinate() {
+  return <div className="p-4">Pagina Teste combinate - in curand</div>;
+}

--- a/dashbord-react/src/TesteSuplimentare.tsx
+++ b/dashbord-react/src/TesteSuplimentare.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function TesteSuplimentare() {
+  return <div className="p-4">Pagina Teste suplimentare - in curand</div>;
+}


### PR DESCRIPTION
## Summary
- ignore persistent data directory
- store books, news and test data under `data/`
- add pages to the React dashboard sidebar
- implement `Banca de grile` component with filtering
- remove unused tabs from `Grile`

## Testing
- `npm install`
- `npm run build`
- `go build ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684893c92cec8323b4b545f84ec73b97