### PR TITLE
Update save progress to exit test

### DIFF
--- a/lib/pages/grile/testegrile/test_page_new.dart
+++ b/lib/pages/grile/testegrile/test_page_new.dart
@@ -118,7 +118,11 @@ class _TestPageState extends State<TestPage> with SingleTickerProviderStateMixin
     await prefs.setBool('test_${key}_completed', false);
     setState(() {
       _hasSavedProgress = true;
+      _showTools = false;
     });
+    if (mounted) {
+      Navigator.of(context).pop();
+    }
   }
 
   Future<void> _loadSavedProgress() async {


### PR DESCRIPTION
## Summary
- close tools menu and return to previous page when saving progress in TestPage

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848995d80188323b17277130a7bae94