### PR TITLE
Update Banca de Grile display and remove unused pages

### DIFF
--- a/dashbord-react/src/App.tsx
+++ b/dashbord-react/src/App.tsx
@@ -1,11 +1,9 @@
 import React, { useEffect, useState } from 'react';
 import BookEditor, { Book as BookType } from './BookEditor';
 import NewsEditor, { NewsItem } from './NewsEditor';
-import CodeEditor from './CodeEditor';
 import CodurileLaZi from './CodurileLaZi';
 import CodeTextTabs from './CodeTextTabs';
 import Grile from './Grile';
-import GrileSpreadsheet from './GrileSpreadsheet';
 import TesteSuplimentare from './TesteSuplimentare';
 import TesteCombinate from './TesteCombinate';
 import Simulari from './Simulari';
@@ -72,7 +70,6 @@ function Login({ onLogin }: LoginProps) {
 
 const sections = [
   { key: 'materie', label: 'Materie', icon: 'menu_book' },
-  { key: 'coduri_lazi', label: 'Codurile actualizate', icon: 'article' },
   { key: 'codurile_la_zi', label: 'Codurile la zi', icon: 'library_books' },
   { key: 'codurile_2_0', label: 'Codurile 2.0', icon: 'library_books' },
   { key: 'noutati', label: 'Noutati', icon: 'feed' },
@@ -81,7 +78,6 @@ const sections = [
   { key: 'combinate', label: 'Teste combinate', icon: 'playlist_add' },
   { key: 'simulari', label: 'Simulari', icon: 'quiz' },
   { key: 'banca', label: 'Banca de grile', icon: 'library_books' },
-  { key: 'grile_2_0', label: 'Grile 2.0', icon: 'grid_on' },
   { key: 'meciuri', label: 'Grile meciuri', icon: 'sports_esports' },
 ];
 
@@ -350,17 +346,11 @@ function Dashboard({ onLogout }: DashboardProps) {
     if (section === 'noutati') {
       return <NewsList items={news} onUpdate={updateNews} onEdit={setEditingNews} />;
     }
-    if (section === 'coduri_lazi') {
-      return <CodeEditor />;
-    }
     if (section === 'codurile_la_zi') {
       return <CodurileLaZi />;
     }
     if (section === 'codurile_2_0') {
       return <CodeTextTabs />;
-    }
-    if (section === 'grile_2_0') {
-      return <GrileSpreadsheet />;
     }
     if (section === 'suplimentare') {
       return <TesteSuplimentare />;

--- a/dashbord-react/src/BancaDeGrile.tsx
+++ b/dashbord-react/src/BancaDeGrile.tsx
@@ -68,13 +68,48 @@ export default function BancaDeGrile() {
         onChange={(e) => setQuery(e.target.value)}
       />
       {Object.entries(grouped).map(([name, gtests]) => (
-        <div key={name} className="mt-4">
+        <div key={name} className="mt-4 space-y-2">
           <h4 className="font-semibold">{name}</h4>
-          <ul className="pl-4 list-disc">
-            {gtests.map((t) => (
-              <li key={t.id}>{t.questions.length} grile</li>
-            ))}
-          </ul>
+          {gtests.map((t) => (
+            <div key={t.id} className="pl-4 space-y-2">
+              {t.questions.map((q, qi) => (
+                <div key={qi} className="border-t pt-2 space-y-1">
+                  <p className="font-bold leading-tight">
+                    {qi + 1}. {q.text}
+                  </p>
+                  {q.answers.map((a, ai) => (
+                    <p key={ai} className="pl-4 leading-tight">
+                      {String.fromCharCode(65 + ai)}. {a}
+                    </p>
+                  ))}
+                  <p className="text-sm italic">
+                    Răspuns corect:{" "}
+                    {q.correct
+                      .map((c) => String.fromCharCode(65 + c))
+                      .join(", ")}
+                    {q.note && (
+                      <span className="ml-2 text-xs text-gray-600">
+                        Nota: {q.note}
+                      </span>
+                    )}
+                  </p>
+                  {q.explanation && (
+                    <div className="text-sm space-y-1">
+                      <p className="font-medium">Explicație:</p>
+                      {q.explanation
+                        .split(/\n+/)
+                        .filter((p) => p.trim())
+                        .map((p, i) => (
+                          <p key={i} className="indent-4">
+                            {p}
+                          </p>
+                        ))}
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          ))}
         </div>
       ))}
     </div>


### PR DESCRIPTION
## Summary
- show full questions in **Banca de grile** instead of just counts
- remove **Codurile actualizate** and **Grile 2.0** pages from the dashboard

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68489e174fd08323a33bb38fe8ac03fd