### PR TITLE
Add exam categories and ordering to tests

### DIFF
--- a/lib/pages/grile/admiterebarou.dart
+++ b/lib/pages/grile/admiterebarou.dart
@@ -24,7 +24,7 @@ class _AdmitereBarouPageState extends State<AdmitereBarouPage> {
 
   final List<Widget> _pages = [
     const PlanuriPage(),
-    const TemePage(),
+    const TemePage(exam: 'Barou'),
     const TesteSupPage(),
     const TesteCombinate(),
     const SimulariPage(),

--- a/lib/pages/grile/admitereinm.dart
+++ b/lib/pages/grile/admitereinm.dart
@@ -26,7 +26,7 @@ class _AdmitereINMPageState extends State<AdmitereINMPage> {
 
   final List<Widget> _pages = [
     const PlanuriPage(),
-    const TemePage(),
+    const TemePage(exam: 'INM'),
     const TesteSupPage(),
     const TesteCombinate(),
     const SimulariPage(),

--- a/lib/pages/grile/admitereinm/teme.dart
+++ b/lib/pages/grile/admitereinm/teme.dart
@@ -63,7 +63,8 @@ final _darkTheme = ThemeData(
 class TemaItem {
   final String title;
   final List<Question> questions;
-  const TemaItem({required this.title, required this.questions});
+  final int order;
+  const TemaItem({required this.title, required this.questions, required this.order});
 }
 
 const _sampleQuestions = [
@@ -128,7 +129,8 @@ class _CustomTab extends StatelessWidget {
 // 5. PAGINA PRINCIPALĂ
 // ────────────────────────────────────────────────────────────────────────────
 class TemePage extends StatefulWidget {
-  const TemePage({super.key});
+  final String exam;
+  const TemePage({super.key, required this.exam});
 
   @override
   State<TemePage> createState() => _TemePageState();
@@ -154,10 +156,14 @@ class _TemePageState extends State<TemePage> with SingleTickerProviderStateMixin
 
   Future<void> _loadTests() async {
     final fetched = await TestsService.fetchTests();
+    final filtered = fetched.where((t) => t.categories.contains(widget.exam)).toList();
     final Map<String, List<TemaItem>> bySubject = {};
-    for (final t in fetched) {
-      final item = TemaItem(title: t.name, questions: t.questions);
+    for (final t in filtered) {
+      final item = TemaItem(title: t.name, questions: t.questions, order: t.order);
       bySubject.putIfAbsent(t.subject, () => []).add(item);
+    }
+    for (final list in bySubject.values) {
+      list.sort((a, b) => a.order.compareTo(b.order));
     }
     setState(() {
       _teme = bySubject.entries
@@ -599,7 +605,7 @@ class MyApp extends StatelessWidget {
         debugShowCheckedModeBanner: false,
         title: 'Teme App',
         theme: p.themeData,
-        home: const TemePage(),
+        home: const TemePage(exam: 'INM'),
       ),
     );
   }

--- a/lib/pages/grile/admitereinr.dart
+++ b/lib/pages/grile/admitereinr.dart
@@ -24,7 +24,7 @@ class _AdmitereINRPageState extends State<AdmitereINRPage> {
 
   final List<Widget> _pages = [
     const PlanuriPage(),
-    const TemePage(),
+    const TemePage(exam: 'INR'),
     const TesteSupPage(),
     const TesteCombinate(),
     const SimulariPage(),

--- a/lib/services/tests_service.dart
+++ b/lib/services/tests_service.dart
@@ -8,12 +8,16 @@ class FetchedTest {
   final String name;
   final String subject;
   final List<Question> questions;
+  final List<String> categories;
+  final int order;
 
   FetchedTest({
     required this.id,
     required this.name,
     required this.subject,
     required this.questions,
+    required this.categories,
+    required this.order,
   });
 
   factory FetchedTest.fromJson(Map<String, dynamic> json) {
@@ -50,6 +54,10 @@ class FetchedTest {
       name: json['name'] ?? '',
       subject: json['subject'] ?? '',
       questions: questions,
+      categories: (json['categories'] as List? ?? ['INM', 'Barou', 'INR'])
+          .map((e) => e.toString())
+          .toList(),
+      order: json['order'] is int ? json['order'] as int : 0,
     );
   }
 }


### PR DESCRIPTION
## Summary
- add `categories` and `order` fields to tests in React dashboard
- allow selecting categories when creating or editing a test
- support moving tests up and down in sidebar
- expose categories and order via API model in Flutter
- filter displayed themes in Flutter by selected exam

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6848a12bf4e0832397a79d4b8ff2a092