### PR TITLE
Add question-level exam filters

### DIFF
--- a/lib/pages/grile/admitereinm/models.dart
+++ b/lib/pages/grile/admitereinm/models.dart
@@ -15,6 +15,7 @@ class Question {
   final List<String> correctAnswers;
   final String explanation;
   final String note;
+  final List<String> categories;
 
   const Question({
     required this.id,
@@ -23,6 +24,7 @@ class Question {
     required this.correctAnswers,
     required this.explanation,
     this.note = '',
+    this.categories = const ['INM', 'Barou', 'INR'],
   });
 }
 

--- a/lib/pages/grile/admitereinm/teme.dart
+++ b/lib/pages/grile/admitereinm/teme.dart
@@ -159,7 +159,10 @@ class _TemePageState extends State<TemePage> with SingleTickerProviderStateMixin
     final filtered = fetched.where((t) => t.categories.contains(widget.exam)).toList();
     final Map<String, List<TemaItem>> bySubject = {};
     for (final t in filtered) {
-      final item = TemaItem(title: t.name, questions: t.questions, order: t.order);
+      final qFiltered =
+          t.questions.where((q) => q.categories.contains(widget.exam)).toList();
+      if (qFiltered.isEmpty) continue;
+      final item = TemaItem(title: t.name, questions: qFiltered, order: t.order);
       bySubject.putIfAbsent(t.subject, () => []).add(item);
     }
     for (final list in bySubject.values) {

--- a/lib/services/tests_service.dart
+++ b/lib/services/tests_service.dart
@@ -46,6 +46,9 @@ class FetchedTest {
         correctAnswers: correctLetters,
         explanation: q['explanation'] ?? '',
         note: q['note']?.toString() ?? '',
+        categories: (q['categories'] as List? ?? ['INM', 'Barou', 'INR'])
+            .map((e) => e.toString())
+            .toList(),
       );
     }).toList();
 


### PR DESCRIPTION
## Summary
- extend `Question` model with `categories` in Flutter and React
- store default categories on import and new question creation
- allow toggling categories for each question in dashboard
- compute test categories from the union of question categories
- filter loaded questions by category in Flutter themes

## Testing
- `npm run build`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848a5031b6483238f03b25bd827a4b7