### PR TITLE
Fix question numbering when categories filtered

### DIFF
--- a/lib/pages/grile/admitereinm/teme.dart
+++ b/lib/pages/grile/admitereinm/teme.dart
@@ -159,10 +159,26 @@ class _TemePageState extends State<TemePage> with SingleTickerProviderStateMixin
     final filtered = fetched.where((t) => t.categories.contains(widget.exam)).toList();
     final Map<String, List<TemaItem>> bySubject = {};
     for (final t in filtered) {
-      final qFiltered =
-          t.questions.where((q) => q.categories.contains(widget.exam)).toList();
+      final qFiltered = t.questions
+          .where((q) => q.categories.contains(widget.exam))
+          .toList();
       if (qFiltered.isEmpty) continue;
-      final item = TemaItem(title: t.name, questions: qFiltered, order: t.order);
+
+      final renumbered = qFiltered.asMap().entries.map<Question>((e) {
+        final q = e.value;
+        return Question(
+          id: e.key + 1,
+          text: q.text,
+          answers: q.answers,
+          correctAnswers: q.correctAnswers,
+          explanation: q.explanation,
+          note: q.note,
+          categories: q.categories,
+        );
+      }).toList();
+
+      final item =
+          TemaItem(title: t.name, questions: renumbered, order: t.order);
       bySubject.putIfAbsent(t.subject, () => []).add(item);
     }
     for (final list in bySubject.values) {


### PR DESCRIPTION
## Summary
- renumber test questions in `TemePage` so IDs start from 1 even when some questions are hidden

## Testing
- `flutter --version` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `dart format -o none lib/pages/grile/admitereinm/teme.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848acd4d4d0832381974880439d7bdc