### PR TITLE
Add bulk explanation feature

### DIFF
--- a/dashbord-react/src/BancaDeGrile.tsx
+++ b/dashbord-react/src/BancaDeGrile.tsx
@@ -7,6 +7,7 @@ interface Question {
   correct: number[];
   note: string;
   explanation?: string;
+  inTheme?: boolean;
 }
 
 interface Test {


### PR DESCRIPTION
## Summary
- add `inTheme` tracking for questions
- highlight moved questions in previous tests
- allow selecting intervals to skip explanation generation
- enable bulk explanation generation in batches of 3

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685451b6eab48323ad82e2240f1d0f57