### PR TITLE
Ignore backend data changes in Vite dev server

### DIFF
--- a/dashbord-react/vite.config.ts
+++ b/dashbord-react/vite.config.ts
@@ -17,6 +17,9 @@ export default defineConfig({
     fs: {
       allow: ['..']
     },
+    watch: {
+      ignored: ['../data/**']
+    },
     proxy: {
       '/api': 'http://localhost:8080'
     }


### PR DESCRIPTION
## Summary
- adjust Vite dev server to ignore `../data` directory so file writes don't trigger restarts

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685458cdaa248323b7add0b88239e3d0