### PR TITLE
Handle localStorage quota errors

### DIFF
--- a/dashbord-react/src/GrileAniAnteriori.tsx
+++ b/dashbord-react/src/GrileAniAnteriori.tsx
@@ -193,7 +193,11 @@ export default function GrileAniAnteriori() {
 
   useEffect(() => {
     if (!allThemes.length) return;
-    localStorage.setItem('savedTests', JSON.stringify(allThemes));
+    try {
+      localStorage.setItem('savedTests', JSON.stringify(allThemes));
+    } catch (err) {
+      console.warn('Unable to persist savedTests in localStorage:', err);
+    }
     fetch('/api/save-tests', {
       method: 'POST',
       headers: {
@@ -206,7 +210,11 @@ export default function GrileAniAnteriori() {
 
   useEffect(() => {
     if (!testsLoaded) return;
-    localStorage.setItem('savedPrevTests', JSON.stringify(savedTests));
+    try {
+      localStorage.setItem('savedPrevTests', JSON.stringify(savedTests));
+    } catch (err) {
+      console.warn('Unable to persist savedPrevTests in localStorage:', err);
+    }
     savePrevTestsRequest(savedTests);
   }, [savedTests, testsLoaded]);
 


### PR DESCRIPTION
## Summary
- avoid crashes in `GrileAniAnteriori` when `localStorage` quota is exceeded

## Testing
- `npm run build` within `dashbord-react`
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68571b5920488323b51f1782c7980fbd