### PR TITLE
Fix localStorage quota error in Grile

### DIFF
--- a/dashbord-react/src/Grile.tsx
+++ b/dashbord-react/src/Grile.tsx
@@ -135,7 +135,11 @@ export default function Grile() {
 
   useEffect(() => {
     if (!testsLoaded) return;
-    localStorage.setItem('savedTests', JSON.stringify(savedTests));
+    try {
+      localStorage.setItem('savedTests', JSON.stringify(savedTests));
+    } catch (err) {
+      console.warn('Unable to persist savedTests in localStorage:', err);
+    }
     fetch('/api/save-tests', {
       method: 'POST',
       headers: {


### PR DESCRIPTION
## Summary
- handle quota errors when persisting tests

## Testing
- `npm run build`
- `go vet ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685792c0d0908323bac8e695ea083e17