### PR TITLE
Improve article range detection and theme assignment

### DIFF
--- a/dashbord-react/src/BancaDeGrile.tsx
+++ b/dashbord-react/src/BancaDeGrile.tsx
@@ -8,6 +8,9 @@ interface Question {
   note: string;
   explanation?: string;
   inTheme?: boolean;
+  articles?: string[];
+  theme?: string;
+  themes?: string[];
 }
 
 interface Test {

--- a/dashbord-react/src/lib/utils.ts
+++ b/dashbord-react/src/lib/utils.ts
@@ -6,9 +6,19 @@ export function cn(...inputs: ClassValue[]) {
 }
 
 export function extractArticleNumbers(text: string): number[] {
-  return Array.from(
-    new Set((text.match(/\b\d{1,4}\b/g) || []).map((n) => parseInt(n, 10)))
-  ).sort((a, b) => a - b);
+  const numbers: number[] = [];
+  const bulletRe = /(?:^|[\n\r])\s*\d+[.)]\s*(\d{1,4})/g;
+  text = text.replace(bulletRe, (_, n) => {
+    numbers.push(parseInt(n, 10));
+    return ' ';
+  });
+
+  const matches = text.match(/\b\d{1,4}\b/g) || [];
+  for (const m of matches) {
+    numbers.push(parseInt(m, 10));
+  }
+
+  return Array.from(new Set(numbers)).sort((a, b) => a - b);
 }
 
 export function collapseNumberRanges(nums: number[]): string[] {
@@ -29,8 +39,25 @@ export function collapseNumberRanges(nums: number[]): string[] {
 }
 
 export function extractArticleRanges(text: string): string[] {
+  const ranges: string[] = [];
+  const rangeRe = /(\d{1,4})\s*[–-]\s*(\d{1,4})/g;
+  text = text.replace(rangeRe, (_, a, b) => {
+    const start = parseInt(a, 10);
+    const end = parseInt(b, 10);
+    if (!isNaN(start) && !isNaN(end)) {
+      ranges.push(`${start}-${end}`);
+    }
+    return ' ';
+  });
+
   const numbers = extractArticleNumbers(text);
-  return collapseNumberRanges(numbers);
+  ranges.push(...collapseNumberRanges(numbers));
+
+  return Array.from(new Set(ranges)).sort((a, b) => {
+    const as = parseInt(a.split('-')[0], 10);
+    const bs = parseInt(b.split('-')[0], 10);
+    return as - bs;
+  });
 }
 
 export function rangeIncludes(range: string, n: number): boolean {


### PR DESCRIPTION
## Summary
- refine article extraction to handle bullet numbers and dash ranges
- allow questions to have multiple themes
- auto-assign questions to all matching themes
- display all themes for each question

## Testing
- `npm install`
- `npm run build`
- `npm test` *(fails: Missing script)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857df62b3e8832394d050b93377c431