### PR TITLE
Add subject detection and auto article parsing

### DIFF
--- a/dashbord-react/src/lib/utils.ts
+++ b/dashbord-react/src/lib/utils.ts
@@ -65,3 +65,20 @@ export function rangeIncludes(range: string, n: number): boolean {
   if (isNaN(e)) return n === s;
   return n >= s && n <= e;
 }
+
+export function detectSubject(text: string): string | undefined {
+  const lower = text.toLowerCase();
+  if (lower.includes('codul de procedura penala') || lower.includes('cod de procedura penala') || lower.includes('procedura penala')) {
+    return 'Drept procesual penal';
+  }
+  if (lower.includes('cod penal')) {
+    return 'Drept penal';
+  }
+  if (lower.includes('codul de procedura civila') || lower.includes('cod de procedura civila') || lower.includes('procedura civila')) {
+    return 'Drept procesual civil';
+  }
+  if (lower.includes('cod civil')) {
+    return 'Drept civil';
+  }
+  return undefined;
+}


### PR DESCRIPTION
## Summary
- detect legal subject from explanations
- store subject for each question and display it
- auto-extract article ranges when generating explanations
- allow editing subject and articles
- regenerate explanations with a single button
- background process generates explanations automatically

## Testing
- `go vet ./...` *(fails: Forbidden storage.googleapis.com)*

------
https://chatgpt.com/codex/tasks/task_e_6857f25a0d2c8323a3841cb4afe41e22