### PR TITLE
Fix dashboard blank page due to missing data

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -540,11 +540,13 @@ func saveBooks(c *gin.Context) {
 }
 
 func listBooks(c *gin.Context) {
-	data, err := ioutil.ReadFile(filepath.Join(dataDir, "books.json"))
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
-	}
+        data, err := ioutil.ReadFile(filepath.Join(dataDir, "books.json"))
+        if os.IsNotExist(err) {
+                data = []byte("[]")
+        } else if err != nil {
+                c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+                return
+        }
 	var books []map[string]interface{}
 	if err := json.Unmarshal(data, &books); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
@@ -576,11 +578,13 @@ func saveNews(c *gin.Context) {
 }
 
 func listNews(c *gin.Context) {
-	data, err := ioutil.ReadFile(filepath.Join(dataDir, "news.json"))
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
-	}
+        data, err := ioutil.ReadFile(filepath.Join(dataDir, "news.json"))
+        if os.IsNotExist(err) {
+                data = []byte("[]")
+        } else if err != nil {
+                c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+                return
+        }
 	var news []map[string]interface{}
 	if err := json.Unmarshal(data, &news); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})

--- a/dashbord-react/README.md
+++ b/dashbord-react/README.md
@@ -14,7 +14,14 @@ npm run dev
 The application will be available at `http://localhost:5173` by default.
 API requests to paths starting with `/api` are proxied to the Go backend
 running on `http://localhost:8080`. Make sure the backend server is running
-for the dashboard to load the books data correctly.
+for the dashboard to load the books data correctly. The backend looks for the
+files `data/books.json` and `data/news.json`. You can copy the sample files from
+this folder the first time you run the server:
+
+```bash
+mkdir -p ../data
+cp books.json news.json ../data/
+```
 
 ### Environment variables
 


### PR DESCRIPTION
## Summary
- avoid 500 errors when `books.json` or `news.json` don't exist
- document how to provide sample dashboard data

## Testing
- `go test ./...` *(fails: directory prefix does not contain main module)*
- `npm run test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68597ed2289c8323848e9c3495b92676