### PR TITLE
Add note parsing to question generator

### DIFF
--- a/dashbord-react/src/Grile.tsx
+++ b/dashbord-react/src/Grile.tsx
@@ -209,6 +209,7 @@ export default function Grile() {
     const aReg = /^(?:R(?:ă|a)spuns\s+)?([A-Za-z])[.)]\s*(.+)$/;
     const correctReg = /^R(?:ă|a)spuns(?:uri)?\s+corect[e]?[:]?\s*(.+)$/i;
     const lettersOnlyReg = /^[A-Za-z](?:\s*,\s*[A-Za-z])+$/;
+    const noteReg = /^Not[ăa]?:?\s*(.+)$/i;
     const ignoreReg = /^Admitere\s/i;
 
     for (const line of lines) {
@@ -282,6 +283,12 @@ export default function Grile() {
         current.correct = letters
           .map((l) => l.charCodeAt(0) - 65)
           .filter((i) => i >= 0 && i < current.answers.length);
+        continue;
+      }
+
+      const noteMatch = line.match(noteReg);
+      if (noteMatch && current) {
+        current.note = noteMatch[1].trim();
         continue;
       }
 


### PR DESCRIPTION
## Summary
- update `parseInput` to read `Nota` lines when creating questions

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6859b8de2dfc8323a0e9ebd248bfc1bb