### PR TITLE
Improve docs for persistent data

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,8 @@ To restore the default examples the server will automatically copy the
 JSON files from the repository if the corresponding files are missing in
 `data/`.
 
+You can change where this data is written by setting the `DATA_DIR`
+environment variable before running the backend. This is useful when
+deploying online so the files can live on a persistent volume and remain
+available across restarts.
+

--- a/backend/README.md
+++ b/backend/README.md
@@ -25,3 +25,12 @@ defines helper functions used by `main.go`.
 
 The server listens on `localhost:8080`. Bind to your machine's IP address or
 `0.0.0.0` if you need to access it from other devices on your network.
+
+### Persistent data
+
+Uploaded books, tests and other editable content are stored inside the
+`data/` directory located at the project root. To keep this information in
+a custom location, set the `DATA_DIR` environment variable before starting
+the server. Pointing this variable to a directory on a mounted volume is the
+recommended way to ensure your files survive server restarts or moving the
+application online.


### PR DESCRIPTION
## Summary
- document how to store dashboard data in a custom directory via `DATA_DIR`
- explain persistence setup in the backend README

## Testing
- `go build ./...` *(fails: Forbidden access to storage.googleapis.com)*

------
https://chatgpt.com/codex/tasks/task_e_6859bc939f508323a47290daeba72b1a