### PR TITLE
Update intervals and article parsing

### DIFF
--- a/dashbord-react/src/GrileAniAnteriori.tsx
+++ b/dashbord-react/src/GrileAniAnteriori.tsx
@@ -69,10 +69,7 @@ export default function GrileAniAnteriori() {
 
   const intervalOptions = [
     { label: '1-20', start: 1, end: 20 },
-    { label: '20-40', start: 20, end: 40 },
-    { label: '40-50', start: 40, end: 50 },
-    { label: '50-70', start: 50, end: 70 },
-    { label: '70-100', start: 70, end: 100 },
+    { label: '51-100', start: 51, end: 100 },
   ];
   const [selectedIntervals, setSelectedIntervals] = useState<string[]>([]);
   const [loadingAllExp, setLoadingAllExp] = useState<Record<string, boolean>>({});
@@ -490,7 +487,7 @@ export default function GrileAniAnteriori() {
   const shouldGenerateExp = (index: number) => {
     const nr = index + 1;
     if (selectedIntervals.length === 0) return true;
-    return intervalOptions.some(
+    return !intervalOptions.some(
       (i) =>
         selectedIntervals.includes(i.label) &&
         nr >= i.start &&

--- a/dashbord-react/src/lib/utils.ts
+++ b/dashbord-react/src/lib/utils.ts
@@ -7,11 +7,23 @@ export function cn(...inputs: ClassValue[]) {
 
 export function extractArticleNumbers(text: string): number[] {
   const numbers: number[] = [];
+
+  // Patterns like "1.697" should be treated as article 1697
+  const dottedRe = /\b(\d{1,3})\.(\d{2,3})\b/g;
+  text = text.replace(dottedRe, (_, a, b) => {
+    numbers.push(parseInt(`${a}${b}`, 10));
+    return ' ';
+  });
+
   const bulletRe = /(?:^|[\n\r])\s*\d+[.)]\s*(\d{1,4})/g;
   text = text.replace(bulletRe, (_, n) => {
     numbers.push(parseInt(n, 10));
     return ' ';
   });
+
+  // Remove references to article paragraphs like "alin. (1)"
+  const alinRe = /alin\.\s*\(?\d{1,4}\)?/gi;
+  text = text.replace(alinRe, ' ');
 
   const matches = text.match(/\b\d{1,4}\b/g) || [];
   for (const m of matches) {


### PR DESCRIPTION
## Summary
- add skip intervals for previous test explanations
- parse numbers like `1.697` correctly when extracting article references

## Testing
- `npm run build` *(fails: vite not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859c616609c83239af2ca9c28128910