### PR TITLE
Improve subject detection in dashboard

### DIFF
--- a/dashbord-react/src/GrileAniAnteriori.tsx
+++ b/dashbord-react/src/GrileAniAnteriori.tsx
@@ -1203,6 +1203,9 @@ export default function GrileAniAnteriori() {
                     Articole: {q.articles.join('; ')}
                   </p>
                 )}
+                {q.subject && (
+                  <p className="text-sm text-gray-500">Materia: {q.subject}</p>
+                )}
                 {(q.themes?.length || q.theme) && (
                   <p className="text-sm text-gray-500">
                     Stabilire tema: {q.themes ? q.themes.join(', ') : q.theme}

--- a/dashbord-react/src/lib/utils.ts
+++ b/dashbord-react/src/lib/utils.ts
@@ -80,16 +80,30 @@ export function rangeIncludes(range: string, n: number): boolean {
 
 export function detectSubject(text: string): string | undefined {
   const lower = text.toLowerCase();
-  if (lower.includes('codul de procedura penala') || lower.includes('cod de procedura penala') || lower.includes('procedura penala')) {
+  if (
+    lower.includes('codul de procedura penala') ||
+    lower.includes('cod de procedura penala') ||
+    lower.includes('procedura penala') ||
+    /c\.?\s*proc\.?\s*pen/.test(lower) ||
+    /\bcpp\b/.test(lower) ||
+    /c\.pr\.pen/.test(lower)
+  ) {
     return 'Drept procesual penal';
   }
-  if (lower.includes('cod penal')) {
+  if (lower.includes('cod penal') || /\bcp\b/.test(lower)) {
     return 'Drept penal';
   }
-  if (lower.includes('codul de procedura civila') || lower.includes('cod de procedura civila') || lower.includes('procedura civila')) {
+  if (
+    lower.includes('codul de procedura civila') ||
+    lower.includes('cod de procedura civila') ||
+    lower.includes('procedura civila') ||
+    /c\.?\s*proc\.?\s*civ/.test(lower) ||
+    /\bcpc\b/.test(lower) ||
+    /c\.pr\.civ/.test(lower)
+  ) {
     return 'Drept procesual civil';
   }
-  if (lower.includes('cod civil')) {
+  if (lower.includes('cod civil') || /\bcc\b/.test(lower) || /c\.\s*civ/.test(lower)) {
     return 'Drept civil';
   }
   return undefined;


### PR DESCRIPTION
## Summary
- enhance `detectSubject` with more patterns for law code abbreviations
- display detected subject in step 5 question preview

## Testing
- `npm run build` in `dashbord-react`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859c8fff6348323bb27b7e70b0323b1