### PR TITLE
Improve article detection logic

### DIFF
--- a/dashbord-react/src/GrileAniAnteriori.tsx
+++ b/dashbord-react/src/GrileAniAnteriori.tsx
@@ -1338,6 +1338,9 @@ export default function GrileAniAnteriori() {
                         onClick={() => setSelectedTestId(test.id)}
                       >
                         {test.name}
+                        {expDone[test.id] && (
+                          <span className="text-green-600 text-xs ml-1">✓</span>
+                        )}
                       </span>
                       <button
                         onClick={() => moveTest(test.id, -1)}
@@ -1358,9 +1361,6 @@ export default function GrileAniAnteriori() {
                       >
                         {loadingAllExp[test.id] ? '...' : 'Generează'}
                       </Button>
-                      {expDone[test.id] && (
-                        <span className="text-green-600 text-xs">✓</span>
-                      )}
                       {intervalOptions.map((opt) => (
                         <label key={opt.label} className="flex items-center space-x-1 text-xs">
                           <input

--- a/dashbord-react/src/lib/utils.ts
+++ b/dashbord-react/src/lib/utils.ts
@@ -24,6 +24,18 @@ export function extractArticleNumbers(text: string): number[] {
   const alinRe = /alin\.\s*\(?\d{1,4}\)?/gi;
   text = text.replace(alinRe, ' ');
 
+  // Ignore references to points or letters such as "pct. 1" or "lit. a)"
+  const pctRe = /pct\.\s*\d{1,4}/gi;
+  text = text.replace(pctRe, ' ');
+  const punctRe = /punct(?:ul)?\s*\d{1,4}/gi;
+  text = text.replace(punctRe, ' ');
+  const litRe = /lit(?:era)?\.\s*[a-zăâîșț]/gi;
+  text = text.replace(litRe, ' ');
+
+  // Remove standalone numbers in parentheses that are not article numbers
+  const parenRe = /\(\s*\d{1,4}\s*\)/g;
+  text = text.replace(parenRe, ' ');
+
   const singleRe = new RegExp(`${artPattern}\\s*(\\d{1,4})`, 'gi');
   let m: RegExpExecArray | null;
   while ((m = singleRe.exec(text)) !== null) {


### PR DESCRIPTION
## Summary
- tweak extraction of article ranges to ignore paragraph/point numbers
- show explanation completion checkmark next to test name

## Testing
- `npx tsc --noEmit` *(fails: Property 'env' does not exist on type 'ImportMeta')*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ad2c9f9588323865f2b39dcd61096