### PR TITLE
Add delete all tests option

### DIFF
--- a/dashbord-react/src/GrileAniAnteriori.tsx
+++ b/dashbord-react/src/GrileAniAnteriori.tsx
@@ -814,6 +814,15 @@ export default function GrileAniAnteriori() {
     savePrevTestsRequest(updated);
   };
 
+  const deleteAllTests = () => {
+    if (!window.confirm('Sigur dorești să ștergi toate testele?')) return;
+    setSavedTests([]);
+    setTests([]);
+    setSelectedTestId(null);
+    setEditingTest(null);
+    savePrevTestsRequest([]);
+  };
+
   const moveTest = (id: string, dir: number) => {
     setSavedTests((prev) => {
       const idx = prev.findIndex((t) => t.id === id);
@@ -1324,9 +1333,14 @@ export default function GrileAniAnteriori() {
               <>
                 <div className="flex items-center justify-between mb-4">
                   <h3 className="text-lg font-semibold">Teste</h3>
-                  <Button onClick={generateExplanationsForAllTests} disabled={Object.values(loadingAllExp).some(Boolean)}>
-                    Generează pentru toate
-                  </Button>
+                  <div className="space-x-2">
+                    <Button onClick={generateExplanationsForAllTests} disabled={Object.values(loadingAllExp).some(Boolean)}>
+                      Generează pentru toate
+                    </Button>
+                    <Button variant="destructive" onClick={deleteAllTests}>
+                      Șterge toate
+                    </Button>
+                  </div>
                 </div>
                 <ul className="pl-4 space-y-1">
                 {savedTests


### PR DESCRIPTION
## Summary
- enable clearing all previous tests with a new function
- add "Șterge toate" button in the "Grile ani anteriori" tab UI

## Testing
- `npm test` *(fails: no test script)*
- `npm run build` in `dashbord-react` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ad9839d148323ba2673e4ee42b253