### PR TITLE
Integrate themes into Materie and add AI summary

### DIFF
--- a/dashbord-react/src/lib/agent.ts
+++ b/dashbord-react/src/lib/agent.ts
@@ -147,3 +147,28 @@ Explicatie: ${q.explanation ?? ''}`.trim();
   const data = await res.json();
   return data.choices?.[0]?.message?.content?.trim() ?? '';
 }
+
+export async function generateThemeSummary(subject: string, interval: string): Promise<string> {
+  const prompt = `Realizeaza o sinteza in stil academic, clar si juridic, folosind doar informatiile din ${subject}.\n` +
+    `Rezuma articolele din intervalul ${interval} si mentioneaza diferentele, asemanarile si exceptiile esentiale.\n` +
+    `Evita comentariile inutile si structureaza raspunsul in paragrafe coerente.`;
+
+  const res = await fetch(
+    `${import.meta.env.VITE_AGENT_ENDPOINT}/api/v1/chat/completions`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${import.meta.env.VITE_AGENT_ACCESS_KEY}`,
+      },
+      body: JSON.stringify({
+        messages: [{ role: 'user', content: prompt }],
+        stream: false,
+      }),
+    }
+  );
+
+  if (!res.ok) throw new Error(`Agent error ${res.status}`);
+  const data = await res.json();
+  return data.choices?.[0]?.message?.content?.trim() ?? '';
+}


### PR DESCRIPTION
## Summary
- extend `Book` with `subject` and `articleInterval`
- add AI summarization button in `BookEditor`
- fetch themes in dashboard and auto-import them as books
- implement `generateThemeSummary` helper for DigitalOcean AI

## Testing
- `npm install` and `npm run build`
- `go build ./...` *(fails: fetching modules from storage.googleapis.com blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686387919d188323a751d1aded0ad31c