### PR TITLE
Add empty Utilizatori/Abonamente page

### DIFF
--- a/dashbord-react/src/App.tsx
+++ b/dashbord-react/src/App.tsx
@@ -9,6 +9,7 @@ import TesteSuplimentare from './TesteSuplimentare';
 import TesteCombinate from './TesteCombinate';
 import Simulari from './Simulari';
 import BancaDeGrile from './BancaDeGrile';
+import UtilizatoriAbonamente from './UtilizatoriAbonamente';
 
 interface LoginProps {
   onLogin: () => void;
@@ -81,6 +82,7 @@ const sections = [
   { key: 'simulari', label: 'Simulari', icon: 'quiz' },
   { key: 'banca', label: 'Banca de grile', icon: 'library_books' },
   { key: 'meciuri', label: 'Grile meciuri', icon: 'sports_esports' },
+  { key: 'utilizatori', label: 'Utilizatori/Abonamente', icon: 'people' },
 ];
 
 interface SidebarProps {
@@ -442,6 +444,9 @@ function Dashboard({ onLogout }: DashboardProps) {
     }
     if (section === 'banca') {
       return <BancaDeGrile />;
+    }
+    if (section === 'utilizatori') {
+      return <UtilizatoriAbonamente />;
     }
     if (section === 'grile_anterioare') {
       return <GrileAniAnteriori />;

--- a/dashbord-react/src/UtilizatoriAbonamente.tsx
+++ b/dashbord-react/src/UtilizatoriAbonamente.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+function UtilizatoriAbonamente() {
+  return (
+    <div className="p-6">
+      <h2 className="text-xl font-semibold mb-2">Utilizatori/Abonamente</h2>
+    </div>
+  );
+}
+
+export default UtilizatoriAbonamente;


### PR DESCRIPTION
## Summary
- add new UtilizatoriAbonamente component
- expose it in the dashboard sidebar and section switch
- compile dashboard to ensure build passes

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68639a0822108323a1b464136252316f