### PR TITLE
Fix missing imports for epub cover extraction

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -1,12 +1,15 @@
 package main
 
 import (
+	"archive/zip"
 	"container/list"
 	"encoding/json"
+	"encoding/xml"
 	"fmt"
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"github.com/gorilla/websocket"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"os"


### PR DESCRIPTION
## Summary
- add archive/zip, encoding/xml, and io to imports

## Testing
- `go build .` *(fails: forbidden download from storage.googleapis.com)*

------
https://chatgpt.com/codex/tasks/task_e_6863ca3493a08323bad5c258407fd0e3