### PR TITLE
Fix epub_view version conflict

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,15 @@ For help getting started with Flutter development, view the
 [online documentation](https://docs.flutter.dev/), which offers tutorials,
 samples, guidance on mobile development, and a full API reference.
 
+After modifying package versions in `pubspec.yaml` (for example updating
+`epub_view` to resolve dependency conflicts), run:
+
+```bash
+flutter pub get
+```
+
+This will download compatible versions and update `pubspec.lock` accordingly.
+
 ## Backend API
 
 The Flutter app communicates with the Go backend found in the `backend/` directory. Start it locally with:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,7 +38,7 @@ dependencies:
   flutter_tts: ^4.2.2
   just_audio: ^0.9.36
   flutter_inappwebview: ^6.1.5
-  epub_view: ^2.1.0
+  epub_view: ^3.2.0
   path_provider: ^2.1.2
   sqflite: ^2.4.2
   path: ^1.9.1


### PR DESCRIPTION
## Summary
- upgrade `epub_view` to a version compatible with `scrollable_positioned_list`
- note that `flutter pub get` should be run after editing `pubspec.yaml`

## Testing
- `go test ./...` *(fails: directory prefix does not contain main module)*
- `go build .` in backend *(fails: blocked downloading from storage.googleapis.com)*

------
https://chatgpt.com/codex/tasks/task_e_6863cda06bec832387b025ba78e5e61f