### PR TITLE
Fix ebook reader reference

### DIFF
--- a/lib/pages/materie/baradecautare.dart
+++ b/lib/pages/materie/baradecautare.dart
@@ -213,7 +213,7 @@ class _BaraDeCautarePageState extends State<BaraDeCautarePage> {
         context,
         MaterialPageRoute(
           builder: (_) => book.file.isNotEmpty
-              ? EbookReaderPage(title: book.title, url: book.file)
+              ? PremiumEbookReaderPage(title: book.title, url: book.file)
               : PovesterePage(
                   titlu: book.title,
                   imagine: book.image,

--- a/lib/pages/materie/carticivil.dart
+++ b/lib/pages/materie/carticivil.dart
@@ -67,7 +67,10 @@ class CartiCivil extends StatelessWidget {
                     context,
                     MaterialPageRoute(
                       builder: (context) => carte.file.isNotEmpty
-                          ? EbookReaderPage(title: carte.title, url: carte.file)
+                          ? PremiumEbookReaderPage(
+                              title: carte.title,
+                              url: carte.file,
+                            )
                           : PovesterePage(
                               titlu: carte.title,
                               imagine: carte.image,

--- a/lib/pages/materie/cartidp.dart
+++ b/lib/pages/materie/cartidp.dart
@@ -67,7 +67,10 @@ class CartiDP extends StatelessWidget {
                     context,
                     MaterialPageRoute(
                       builder: (context) => carte.file.isNotEmpty
-                          ? EbookReaderPage(title: carte.title, url: carte.file)
+                          ? PremiumEbookReaderPage(
+                              title: carte.title,
+                              url: carte.file,
+                            )
                           : PovesterePage(
                               titlu: carte.title,
                               imagine: carte.image,

--- a/lib/pages/materie/cartidpc.dart
+++ b/lib/pages/materie/cartidpc.dart
@@ -67,7 +67,10 @@ class CartiDPC extends StatelessWidget {
                     context,
                     MaterialPageRoute(
                       builder: (context) => carte.file.isNotEmpty
-                          ? EbookReaderPage(title: carte.title, url: carte.file)
+                          ? PremiumEbookReaderPage(
+                              title: carte.title,
+                              url: carte.file,
+                            )
                           : PovesterePage(
                               titlu: carte.title,
                               imagine: carte.image,

--- a/lib/pages/materie/cartidpp.dart
+++ b/lib/pages/materie/cartidpp.dart
@@ -67,7 +67,10 @@ class CartiDPP extends StatelessWidget {
                     context,
                     MaterialPageRoute(
                       builder: (context) => carte.file.isNotEmpty
-                          ? EbookReaderPage(title: carte.title, url: carte.file)
+                          ? PremiumEbookReaderPage(
+                              title: carte.title,
+                              url: carte.file,
+                            )
                           : PovesterePage(
                               titlu: carte.title,
                               imagine: carte.image,


### PR DESCRIPTION
## Summary
- fix calls to `EbookReaderPage` by using `PremiumEbookReaderPage`

## Testing
- `dart format` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863daccf03c832383e1b8b212fd8394