### PR TITLE
Fix epub paging and smoother cover fade

### DIFF
--- a/lib/pages/book_cover_page.dart
+++ b/lib/pages/book_cover_page.dart
@@ -19,12 +19,14 @@ class _BookCoverPageState extends State<BookCoverPage>
     super.initState();
     _controller = AnimationController(
       vsync: this,
-      duration: const Duration(milliseconds: 500),
+      duration: const Duration(milliseconds: 800),
     );
-    _fade = CurvedAnimation(parent: _controller, curve: Curves.easeIn);
-    _controller.forward().then((_) async {
-      await Future.delayed(const Duration(milliseconds: 400));
-      if (mounted) {
+    _fade = Tween<double>(begin: 1, end: 0).animate(
+      CurvedAnimation(parent: _controller, curve: Curves.easeOutCubic),
+    );
+    _controller.forward();
+    _controller.addStatusListener((status) {
+      if (status == AnimationStatus.completed && mounted) {
         Navigator.pushReplacement(
           context,
           MaterialPageRoute(builder: (_) => widget.nextPage),

--- a/lib/utils/epub_utils.dart
+++ b/lib/utils/epub_utils.dart
@@ -102,3 +102,24 @@ ParseParagraphsResult parseParagraphs(List<EpubChapter> chapters) {
 
   return ParseParagraphsResult(paragraphs, chapterIndexes);
 }
+
+class PageData {
+  PageData(this.html, this.preview);
+
+  final String html;
+  final String preview;
+}
+
+List<PageData> parsePages(List<EpubChapter> chapters) {
+  final List<PageData> pages = [];
+  for (final chapter in chapters) {
+    final document = chapterDocument(chapter);
+    if (document == null) continue;
+    final body = document.getElementsByTagName('body').first;
+    final html = body.outerHtml;
+    String preview = body.text.trim().replaceAll(RegExp(r'\s+'), ' ');
+    if (preview.length > 80) preview = '${preview.substring(0, 80)}...';
+    pages.add(PageData(html, preview));
+  }
+  return pages;
+}


### PR DESCRIPTION
## Summary
- show EPUB chapters as separate pages rather than splitting by paragraph
- show snippet previews in page thumbnails
- make book cover fade out smoothly into reader

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6863f248be7c8323a83ef4d4e7d151ec