### PR TITLE
Fix test page overflow and saved progress bug

### DIFF
--- a/lib/pages/grile/testegrile/test_page_new.dart
+++ b/lib/pages/grile/testegrile/test_page_new.dart
@@ -138,10 +138,20 @@ class _TestPageState extends State<TestPage> with SingleTickerProviderStateMixin
       _selectedAnswers = decoded
           .map<List<String>>((e) => List<String>.from(e as List))
           .toList();
+
+      // Ensure the loaded answers list matches the current number of questions
+      if (_selectedAnswers.length < widget.questions.length) {
+        _selectedAnswers.addAll(List.generate(
+            widget.questions.length - _selectedAnswers.length, (_) => []));
+      } else if (_selectedAnswers.length > widget.questions.length) {
+        _selectedAnswers =
+            _selectedAnswers.sublist(0, widget.questions.length);
+      }
+
       _answeredQuestions =
           _selectedAnswers.map((e) => e.isNotEmpty).toList();
-      _progress =
-          _selectedAnswers.where((a) => a.isNotEmpty).length / widget.questions.length;
+      _progress = _selectedAnswers.where((a) => a.isNotEmpty).length /
+          widget.questions.length;
     }
 
     if (completed) {
@@ -756,16 +766,20 @@ class _TestPageState extends State<TestPage> with SingleTickerProviderStateMixin
                   Padding(
                     padding: const EdgeInsets.only(top: 8),
                     child: Row(
-                      mainAxisAlignment: MainAxisAlignment.end,
+                      crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
                         Icon(Icons.info_outline,
                             size: 14, color: secondaryTextColor),
                         const SizedBox(width: 4),
-                        Text(
-                          'Nota: ${question.note}',
-                          style: GoogleFonts.poppins(
-                            fontSize: 12,
-                            color: secondaryTextColor,
+                        Expanded(
+                          child: Text(
+                            'Nota: ${question.note}',
+                            textAlign: TextAlign.center,
+                            style: GoogleFonts.poppins(
+                              fontSize: 12,
+                              color: secondaryTextColor,
+                            ),
+                            maxLines: 2,
                           ),
                         ),
                       ],


### PR DESCRIPTION
## Summary
- prevent range errors when loading saved progress by normalizing loaded answers length
- wrap note text to avoid overflow in question cards

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6864b900dfec8323a2c19a841cadde0c