### PR TITLE
Add internet_file dependency lock entry

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -805,6 +805,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.19.0"
+  internet_file:
+    dependency: "direct main"
+    description:
+      name: internet_file
+      sha256: c3e6aa0c1cc6c08e701bb91019a7784fece1f64e18464f53df1200caa7598b68
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.0"
   io:
     dependency: transitive
     description:


### PR DESCRIPTION
## Summary
- update `pubspec.lock` with missing `internet_file` package entry

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864c13b48f883238fe2e563f8969c53