### PR TITLE
Fix http conflict by removing internet_file

### DIFF
--- a/lib/pages/simple_ebook_view_page.dart
+++ b/lib/pages/simple_ebook_view_page.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:epub_view/epub_view.dart';
-import 'package:internet_file/internet_file.dart';
+import 'package:http/http.dart' as http;
 
 class SimpleEbookViewPage extends StatefulWidget {
   final String title;
@@ -18,8 +18,14 @@ class _SimpleEbookViewPageState extends State<SimpleEbookViewPage> {
   void initState() {
     super.initState();
     _controller = EpubController(
-      document: EpubDocument.openData(InternetFile.get(widget.url)),
+      document: EpubDocument.openData(_loadEpub()),
     );
+  }
+
+  Future<List<int>> _loadEpub() async {
+    final response = await http.get(Uri.parse(widget.url));
+    if (response.statusCode == 200) return response.bodyBytes;
+    throw Exception('Failed to load ebook');
   }
 
   @override

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -805,14 +805,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.19.0"
-  internet_file:
-    dependency: "direct main"
-    description:
-      name: internet_file
-      sha256: c3e6aa0c1cc6c08e701bb91019a7784fece1f64e18464f53df1200caa7598b68
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.2.0"
   io:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -49,7 +49,6 @@ dependencies:
   json_annotation: ^4.8.1
   image_picker: ^1.0.4
   permission_handler: ^11.3.0
-  internet_file: ^1.2.0
   web_socket_channel: ^2.4.0
   pull_to_refresh: ^2.0.0
   dio: ^5.4.0


### PR DESCRIPTION
## Summary
- remove `internet_file` package and use `http` directly
- update `pubspec.yaml` and lock file accordingly

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864c246d1308323ac8d15e3a5d6be14