### PR TITLE
Add PDF upload and viewer

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -1003,14 +1003,20 @@ func uploadBookFile(c *gin.Context) {
 	}
 
 	os.MkdirAll(filepath.Join(uploadsDir, "ebook"), os.ModePerm)
-	fname := uuid.New().String() + filepath.Ext(file.Filename)
+	ext := strings.ToLower(filepath.Ext(file.Filename))
+	fname := uuid.New().String() + ext
 	path := filepath.Join(uploadsDir, "ebook", fname)
 	if err := c.SaveUploadedFile(file, path); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to save"})
 		return
 	}
 
-	cover := extractEpubCover(path)
+	var cover string
+	if ext == ".epub" {
+		cover = extractEpubCover(path)
+	} else if ext == ".pdf" {
+		cover = extractPDFCover(path)
+	}
 
 	scheme := "http"
 	if c.Request.TLS != nil {
@@ -1112,6 +1118,11 @@ func extractEpubCover(epubPath string) string {
 			break
 		}
 	}
+	return ""
+}
+
+func extractPDFCover(pdfPath string) string {
+	// PDF cover extraction not implemented
 	return ""
 }
 

--- a/dashbord-react/src/BookEditor.tsx
+++ b/dashbord-react/src/BookEditor.tsx
@@ -57,7 +57,7 @@ export default function BookEditor({ book, onSave, onCancel }: EditorProps) {
         {form.image && (
           <img src={form.image} alt="preview" className="w-32" />
         )}
-        <input type="file" accept=".epub" onChange={handleBookFile} />
+        <input type="file" accept=".epub,.pdf" onChange={handleBookFile} />
         {uploading && <div className="text-sm text-gray-500">Uploading...</div>}
       </div>
       <button

--- a/lib/pages/materie/baradecautare.dart
+++ b/lib/pages/materie/baradecautare.dart
@@ -4,6 +4,7 @@ import 'package:google_fonts/google_fonts.dart';
 import '../../services/book_service.dart';
 import '../poveste_page.dart';
 import '../ebook_reader_page.dart';
+import '../pdf_viewer_page.dart';
 import '../book_cover_page.dart';
 
 class BaraDeCautarePage extends StatefulWidget {
@@ -211,14 +212,19 @@ class _BaraDeCautarePageState extends State<BaraDeCautarePage> {
         style: GoogleFonts.poppins(fontWeight: FontWeight.w600),
       ),
       onTap: () {
-        final page = book.file.isNotEmpty
-            ? PremiumEbookReaderPage(title: book.title, url: book.file)
-            : PovesterePage(
-                titlu: book.title,
-                imagine: book.image,
-                continut: book.content,
-                progress: 0.0,
-              );
+        Widget page;
+        if (book.file.toLowerCase().endsWith('.pdf')) {
+          page = PdfViewerPage(title: book.title, url: book.file);
+        } else if (book.file.isNotEmpty) {
+          page = PremiumEbookReaderPage(title: book.title, url: book.file);
+        } else {
+          page = PovesterePage(
+            titlu: book.title,
+            imagine: book.image,
+            continut: book.content,
+            progress: 0.0,
+          );
+        }
         Navigator.push(
           context,
           MaterialPageRoute(

--- a/lib/pages/materie/carticivil.dart
+++ b/lib/pages/materie/carticivil.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import '../poveste_page.dart';
 import '../ebook_reader_page.dart';
+import '../pdf_viewer_page.dart';
 import '../book_cover_page.dart';
 import '../../services/book_service.dart';
 
@@ -64,17 +65,22 @@ class CartiCivil extends StatelessWidget {
               borderRadius: BorderRadius.circular(12),
               child: InkWell(
                 onTap: () {
-                  final page = carte.file.isNotEmpty
-                      ? PremiumEbookReaderPage(
-                          title: carte.title,
-                          url: carte.file,
-                        )
-                      : PovesterePage(
-                          titlu: carte.title,
-                          imagine: carte.image,
-                          continut: carte.content,
-                          progress: 0.0,
-                        );
+                  Widget page;
+                  if (carte.file.toLowerCase().endsWith('.pdf')) {
+                    page = PdfViewerPage(title: carte.title, url: carte.file);
+                  } else if (carte.file.isNotEmpty) {
+                    page = PremiumEbookReaderPage(
+                      title: carte.title,
+                      url: carte.file,
+                    );
+                  } else {
+                    page = PovesterePage(
+                      titlu: carte.title,
+                      imagine: carte.image,
+                      continut: carte.content,
+                      progress: 0.0,
+                    );
+                  }
                   Navigator.push(
                     context,
                     MaterialPageRoute(

--- a/lib/pages/materie/cartidp.dart
+++ b/lib/pages/materie/cartidp.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import '../poveste_page.dart';
 import '../ebook_reader_page.dart';
+import '../pdf_viewer_page.dart';
 import '../book_cover_page.dart';
 import '../../services/book_service.dart';
 
@@ -64,17 +65,22 @@ class CartiDP extends StatelessWidget {
               borderRadius: BorderRadius.circular(12),
               child: InkWell(
                 onTap: () {
-                  final page = carte.file.isNotEmpty
-                      ? PremiumEbookReaderPage(
-                          title: carte.title,
-                          url: carte.file,
-                        )
-                      : PovesterePage(
-                          titlu: carte.title,
-                          imagine: carte.image,
-                          continut: carte.content,
-                          progress: 0.0,
-                        );
+                  Widget page;
+                  if (carte.file.toLowerCase().endsWith('.pdf')) {
+                    page = PdfViewerPage(title: carte.title, url: carte.file);
+                  } else if (carte.file.isNotEmpty) {
+                    page = PremiumEbookReaderPage(
+                      title: carte.title,
+                      url: carte.file,
+                    );
+                  } else {
+                    page = PovesterePage(
+                      titlu: carte.title,
+                      imagine: carte.image,
+                      continut: carte.content,
+                      progress: 0.0,
+                    );
+                  }
                   Navigator.push(
                     context,
                     MaterialPageRoute(

--- a/lib/pages/materie/cartidpc.dart
+++ b/lib/pages/materie/cartidpc.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import '../poveste_page.dart';
 import '../ebook_reader_page.dart';
+import '../pdf_viewer_page.dart';
 import '../book_cover_page.dart';
 import '../../services/book_service.dart';
 
@@ -64,17 +65,22 @@ class CartiDPC extends StatelessWidget {
               borderRadius: BorderRadius.circular(12),
               child: InkWell(
                 onTap: () {
-                  final page = carte.file.isNotEmpty
-                      ? PremiumEbookReaderPage(
-                          title: carte.title,
-                          url: carte.file,
-                        )
-                      : PovesterePage(
-                          titlu: carte.title,
-                          imagine: carte.image,
-                          continut: carte.content,
-                          progress: 0.0,
-                        );
+                  Widget page;
+                  if (carte.file.toLowerCase().endsWith('.pdf')) {
+                    page = PdfViewerPage(title: carte.title, url: carte.file);
+                  } else if (carte.file.isNotEmpty) {
+                    page = PremiumEbookReaderPage(
+                      title: carte.title,
+                      url: carte.file,
+                    );
+                  } else {
+                    page = PovesterePage(
+                      titlu: carte.title,
+                      imagine: carte.image,
+                      continut: carte.content,
+                      progress: 0.0,
+                    );
+                  }
                   Navigator.push(
                     context,
                     MaterialPageRoute(

--- a/lib/pages/materie/cartidpp.dart
+++ b/lib/pages/materie/cartidpp.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import '../poveste_page.dart';
 import '../ebook_reader_page.dart';
+import '../pdf_viewer_page.dart';
 import '../book_cover_page.dart';
 import '../../services/book_service.dart';
 
@@ -64,17 +65,22 @@ class CartiDPP extends StatelessWidget {
               borderRadius: BorderRadius.circular(12),
               child: InkWell(
                 onTap: () {
-                  final page = carte.file.isNotEmpty
-                      ? PremiumEbookReaderPage(
-                          title: carte.title,
-                          url: carte.file,
-                        )
-                      : PovesterePage(
-                          titlu: carte.title,
-                          imagine: carte.image,
-                          continut: carte.content,
-                          progress: 0.0,
-                        );
+                  Widget page;
+                  if (carte.file.toLowerCase().endsWith('.pdf')) {
+                    page = PdfViewerPage(title: carte.title, url: carte.file);
+                  } else if (carte.file.isNotEmpty) {
+                    page = PremiumEbookReaderPage(
+                      title: carte.title,
+                      url: carte.file,
+                    );
+                  } else {
+                    page = PovesterePage(
+                      titlu: carte.title,
+                      imagine: carte.image,
+                      continut: carte.content,
+                      progress: 0.0,
+                    );
+                  }
                   Navigator.push(
                     context,
                     MaterialPageRoute(

--- a/lib/pages/pdf_viewer_page.dart
+++ b/lib/pages/pdf_viewer_page.dart
@@ -1,0 +1,85 @@
+import 'package:flutter/material.dart';
+import 'package:syncfusion_flutter_pdfviewer/pdfviewer.dart';
+import 'package:http/http.dart' as http;
+import 'dart:typed_data';
+
+class PdfViewerPage extends StatefulWidget {
+  final String title;
+  final String url;
+  const PdfViewerPage({super.key, required this.title, required this.url});
+
+  @override
+  State<PdfViewerPage> createState() => _PdfViewerPageState();
+}
+
+class _PdfViewerPageState extends State<PdfViewerPage> {
+  late PdfViewerController _controller;
+  bool _darkMode = false;
+  bool _loading = true;
+  Uint8List? _data;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = PdfViewerController();
+    _load();
+  }
+
+  Future<void> _load() async {
+    try {
+      final res = await http.get(Uri.parse(widget.url));
+      if (res.statusCode == 200) {
+        _data = res.bodyBytes;
+      }
+    } catch (_) {}
+    if (mounted) setState(() => _loading = false);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = _darkMode ? ThemeData.dark() : ThemeData.light();
+    return Theme(
+      data: theme,
+      child: Scaffold(
+        appBar: AppBar(
+          title: Text(widget.title),
+          actions: [
+            IconButton(
+              icon: Icon(_darkMode ? Icons.dark_mode : Icons.light_mode),
+              onPressed: () => setState(() => _darkMode = !_darkMode),
+            ),
+          ],
+        ),
+        body: _loading
+            ? const Center(child: CircularProgressIndicator())
+            : _data != null
+                ? SfPdfViewer.memory(_data!, controller: _controller)
+                : const Center(child: Text('Failed to load PDF')),
+        floatingActionButton: _loading
+            ? null
+            : Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  FloatingActionButton(
+                    heroTag: 'zoom_in',
+                    mini: true,
+                    onPressed: () =>
+                        _controller.zoomLevel = _controller.zoomLevel + 0.25,
+                    child: const Icon(Icons.zoom_in),
+                  ),
+                  const SizedBox(height: 8),
+                  FloatingActionButton(
+                    heroTag: 'zoom_out',
+                    mini: true,
+                    onPressed: () {
+                      final newLevel = _controller.zoomLevel - 0.25;
+                      _controller.zoomLevel = newLevel.clamp(1.0, 5.0);
+                    },
+                    child: const Icon(Icons.zoom_out),
+                  ),
+                ],
+              ),
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -40,6 +40,7 @@ dependencies:
   just_audio: ^0.9.36
   flutter_inappwebview: ^6.1.5
   epub_view: ^3.2.0
+  syncfusion_flutter_pdfviewer: ^23.1.44
   path_provider: ^2.1.2
   sqflite: ^2.4.2
   path: ^1.9.1


### PR DESCRIPTION
## Summary
- allow uploading PDF files in the React dashboard
- extend backend upload handler to accept .pdf
- add a PDF viewer page in Flutter using Syncfusion
- open PDF books using the new viewer
- add pdf viewer dependency

## Testing
- `flutter pub get` *(fails: `flutter` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6864ca2aee908323b409320b97279212