### PR TITLE
Fix WebUri usage in PDF viewer

### DIFF
--- a/lib/pages/pdf_viewer_page.dart
+++ b/lib/pages/pdf_viewer_page.dart
@@ -21,7 +21,7 @@ class _PdfViewerPageState extends State<PdfViewerPage> {
       body: Stack(
         children: [
           InAppWebView(
-            initialUrlRequest: URLRequest(url: Uri.parse(widget.url)),
+            initialUrlRequest: URLRequest(url: WebUri(widget.url)),
             onWebViewCreated: (controller) => _controller = controller,
             onLoadStop: (_, __) => setState(() => _loading = false),
           ),


### PR DESCRIPTION
## Summary
- fix URLRequest parameter type for latest flutter_inappwebview

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6864ced9eff48323a4a357eb4ebde0fd