### PR TITLE
Fix PDF.js import path in BookEditor

### DIFF
--- a/dashbord-react/src/BookEditor.tsx
+++ b/dashbord-react/src/BookEditor.tsx
@@ -30,9 +30,9 @@ export default function BookEditor({ book, onSave, onCancel }: EditorProps) {
 
     if (file.type === 'application/pdf') {
       try {
-        const pdfjs = await import('pdfjs-dist/legacy/build/pdf');
+        const pdfjs = await import('pdfjs-dist/legacy/build/pdf.mjs');
         pdfjs.GlobalWorkerOptions.workerSrc =
-          `https://cdn.jsdelivr.net/npm/pdfjs-dist@${pdfjs.version}/legacy/build/pdf.worker.min.js`;
+          `https://cdn.jsdelivr.net/npm/pdfjs-dist@${pdfjs.version}/legacy/build/pdf.worker.min.mjs`;
         const buf = await file.arrayBuffer();
         const doc = await pdfjs.getDocument({ data: buf }).promise;
         const page = await doc.getPage(1);


### PR DESCRIPTION
## Summary
- update `BookEditor.tsx` to use correct path for pdfjs

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6864dbb3595c832399d2157553f26f70