### PR TITLE
Fix flutter dependency conflicts

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -705,10 +705,10 @@ packages:
     dependency: "direct main"
     description:
       name: http
-      sha256: "2c11f3f94c687ee9bad77c171151672986360b2b001d109814ee7140b2cf261b"
+      sha256: "5895291c13fa8a3bd82e76d5627f69e0d85ca6a30dcac95c4ea19a5d555879c2"
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "0.13.6"
   http_multi_server:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -47,7 +47,7 @@ dependencies:
   path: ^1.9.1
   flutter_local_notifications: ^16.3.2
   flutter_staggered_grid_view: ^0.7.0
-  http: ^1.4.0
+  http: ^0.13.6
   json_annotation: ^4.8.1
   image_picker: ^1.0.4
   permission_handler: ^11.3.0


### PR DESCRIPTION
## Summary
- relax `http` dependency to resolve package conflict with `internet_file`

## Testing
- `dart pub get` *(fails: dart not installed)*
- `flutter pub get` *(fails: flutter not installed)*


------
https://chatgpt.com/codex/tasks/task_e_6864e3dd81948323bfdbd3552b635f9a