### PR TITLE
Fix pubspec dependency conflict by downgrading lottie

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -905,10 +905,9 @@ packages:
     dependency: "direct main"
     description:
       name: lottie
-      sha256: c5fa04a80a620066c15cf19cc44773e19e9b38e989ff23ea32e5903ef1015950
       url: "https://pub.dev"
     source: hosted
-    version: "3.3.1"
+    version: "3.0.0"
   markdown:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   flutter_localizations:
     sdk: flutter
   cupertino_icons: ^1.0.2
-  lottie: ^3.3.1
+  lottie: ^3.0.0
   fl_chart: ^0.66.2
   google_fonts: 4.0.4
   shared_preferences: ^2.2.2


### PR DESCRIPTION
## Summary
- downgrade `lottie` to version `^3.0.0` to avoid requiring `http ^1.0.0`
- update `pubspec.lock` accordingly

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864e53d71f08323b4166e1894068ac3