### PR TITLE
Fix PDF controller initialization

### DIFF
--- a/lib/pages/pdf_viewer_page.dart
+++ b/lib/pages/pdf_viewer_page.dart
@@ -45,10 +45,10 @@ class _PdfViewerPageState extends State<PdfViewerPage> {
   }
 
   Future<void> _loadDocument() async {
-    final documentFuture = _createDocument();
+    final document = await _createDocument();
     if (!mounted) return;
     setState(() {
-      _controller = PdfControllerPinch(document: documentFuture);
+      _controller = PdfControllerPinch(document: document);
     });
   }
 


### PR DESCRIPTION
## Summary
- ensure `_loadDocument` awaits `Future<PdfDocument>` before creating controller

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864ed65b4dc8323b1eb2aa4a1832288