### PR TITLE
Add create section control

### DIFF
--- a/dashbord-react/src/Grile.tsx
+++ b/dashbord-react/src/Grile.tsx
@@ -1478,6 +1478,40 @@ export default function Grile() {
                       >
                         Eliminare secțiuni
                       </Button>
+                      {addingSection ? (
+                        <div className="inline-flex items-center space-x-2">
+                          <input
+                            className="border p-1 rounded flex-1"
+                            value={newSectionName}
+                            onChange={(e) => setNewSectionName(e.target.value)}
+                          />
+                          <Button
+                            size="sm"
+                            onClick={() => {
+                              addSectionToTest(newSectionName);
+                              setNewSectionName('');
+                              setAddingSection(false);
+                            }}
+                          >
+                            Salvează
+                          </Button>
+                          <Button
+                            size="sm"
+                            variant="ghost"
+                            onClick={() => setAddingSection(false)}
+                          >
+                            Renunță
+                          </Button>
+                        </div>
+                      ) : (
+                        <Button
+                          size="sm"
+                          variant="secondary"
+                          onClick={() => setAddingSection(true)}
+                        >
+                          Creează secțiune
+                        </Button>
+                      )}
                       <Button
                         onClick={() =>
                           setEditingTest(() => {
@@ -1527,34 +1561,6 @@ export default function Grile() {
                         </>
                       );
                     })()}
-                    {addingSection ? (
-                      <div className="flex items-center space-x-2 mb-2">
-                        <input
-                          className="border p-1 rounded flex-1"
-                          value={newSectionName}
-                          onChange={(e) => setNewSectionName(e.target.value)}
-                        />
-                        <Button
-                          size="sm"
-                          onClick={() => {
-                            addSectionToTest(newSectionName);
-                            setNewSectionName('');
-                            setAddingSection(false);
-                          }}
-                        >
-                          Salvează
-                        </Button>
-                      </div>
-                    ) : (
-                      <Button
-                        size="sm"
-                        variant="secondary"
-                        className="mb-2"
-                        onClick={() => setAddingSection(true)}
-                      >
-                        Adaugă secțiune
-                      </Button>
-                    )}
                   </div>
                 </>
               )}


### PR DESCRIPTION
## Summary
- add a new 'Creează secțiune' button in the test toolbar so sections can be predefined
- move the section creation UI from the bottom of the page to the toolbar
- keep existing editing workflow unchanged

## Testing
- `npm install`
- `npm run build`

`flutter` was not available so Flutter tests could not be run.

------
https://chatgpt.com/codex/tasks/task_e_6867b8421fc48323a9b2fbf82f903f8f