### PR TITLE
Fix question numbering

### DIFF
--- a/lib/services/tests_service.dart
+++ b/lib/services/tests_service.dart
@@ -3,6 +3,11 @@ import 'package:http/http.dart' as http;
 import '../pages/backend/services/api_service.dart';
 import '../pages/grile/admitereinm/models.dart';
 
+String _cleanQuestionText(String text) {
+  final reg = RegExp(r'^\s*\d{1,3}\s*[\.\)\-:]\s*');
+  return text.replaceFirst(reg, '');
+}
+
 class FetchedTest {
   final String id;
   final String name;
@@ -54,7 +59,7 @@ class FetchedTest {
       }
       return Question(
         id: entry.key + 1,
-        text: q['text'] ?? '',
+        text: _cleanQuestionText(q['text']?.toString() ?? ''),
         answers: answers,
         correctAnswers: correctLetters,
         explanation: q['explanation'] ?? '',


### PR DESCRIPTION
## Summary
- strip existing numbering from question text in `tests_service`
- rebuild questions using cleaned text

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868cf0def20832396607edb0844258a